### PR TITLE
fix: grant start-dragging so the frameless window can be dragged

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
-    "core:window:allow-close"
+    "core:window:allow-close",
+    "core:window:allow-start-dragging"
   ]
 }


### PR DESCRIPTION
## Problem

The shell page marks its toolbar with `data-tauri-drag-region`, but dragging does nothing on any platform: the injected drag script invokes `plugin:window|start_dragging` on mousedown, which the ACL **silently denies** — `core:window:default` does not include `allow-start-dragging` and the capabilities file never granted it.

## Fix

Add `core:window:allow-start-dragging` to `capabilities/default.json`.

Double-click-to-maximize on the drag region uses the same ACL path and is fixed by the same change (`allow-internal-toggle-maximize` is already part of the default set).

## Tested

- Frameless window (macOS build): dragging by the toolbar works after this change; before it, no drag ever started and the denial was invisible (nothing surfaces to the page console).
