### PR TITLE
fix(macos): standard menu roles — Edit shortcuts, ⌘Q quit, Window menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,7 +17,7 @@ use std::thread;
 use std::time::Duration;
 
 use tauri::menu::CheckMenuItem;
-use tauri::{AppHandle, Manager, State, WindowEvent, Wry};
+use tauri::{AppHandle, Manager, RunEvent, State, WindowEvent, Wry};
 use tauri_plugin_autostart::ManagerExt as _;
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt as _, Modifiers, Shortcut, ShortcutState};
 use tauri_plugin_notification::NotificationExt;
@@ -502,9 +502,9 @@ fn handle_menu_action(app: &AppHandle, id: &str) {
             }
         }
         menu::MENU_QUIT => {
-            // stop() is a safe no-op in attach mode (pid stays None there),
-            // so this only tears down a server we actually spawned.
-            server::stop(&state.server);
+            // The spawned server is torn down in the ExitRequested handler
+            // at the end of run() — the single place covering every quit
+            // path (app-menu ⌘Q role, tray 退出, updater restart).
             app.exit(0);
         }
         _ => {}
@@ -645,9 +645,9 @@ pub fn run() {
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
                 // Tray-resident mode: closing the window hides it but leaves
-                // the dsh server running in the background. Only the
-                // menu/tray "退出" action (MENU_QUIT, app.exit) stops the
-                // server and actually exits the process.
+                // the dsh server running in the background. Quitting (⌘Q /
+                // tray 退出) tears the server down in the ExitRequested
+                // handler and then exits the process.
                 api.prevent_close();
                 let _ = window.hide();
 
@@ -665,8 +665,20 @@ pub fn run() {
             }
         })
         .on_menu_event(|app, event| handle_menu_action(app, event.id.as_ref()))
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            // Tear down the spawned dsh server before the process exits —
+            // otherwise the child is orphaned and keeps serving. Every quit
+            // path (the app-menu ⌘Q role on macOS, the tray "退出" item,
+            // updater restarts) funnels into ExitRequested before the event
+            // loop ends, so this is the one place it needs to happen.
+            if let RunEvent::ExitRequested { .. } = event {
+                if let Some(state) = app.try_state::<AppState>() {
+                    server::stop(&state.server);
+                }
+            }
+        });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use tauri::menu::{CheckMenuItem, Menu, MenuItem};
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
 #[cfg(target_os = "macos")]
 use tauri::menu::Submenu;
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -28,7 +28,25 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let open_data_dir = MenuItem::with_id(app, MENU_OPEN_DATA_DIR, "打开数据目录 (~/.dsh)", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, MENU_QUIT, "退出", true, None::<&str>)?;
     let file = Submenu::with_items(app, "文件", true, &[&open_browser, &restart, &open_data_dir, &quit])?;
-    Ok(Menu::with_items(app, &[&file])?)
+    // macOS 上 Cmd+C / Cmd+V / Cmd+X / Cmd+A 等快捷键必须由菜单中的标准
+    // "编辑"项提供（通过 responder chain 分发到 WebView），缺少它们会导致
+    // 剪切/复制/粘贴失效。PredefinedMenuItem 的角色项会自动带上正确的
+    // 快捷键与选择器，无需手动注册处理逻辑。
+    let edit = Submenu::with_items(
+        app,
+        "编辑",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app, None)?,
+            &PredefinedMenuItem::redo(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None)?,
+            &PredefinedMenuItem::copy(app, None)?,
+            &PredefinedMenuItem::paste(app, None)?,
+            &PredefinedMenuItem::select_all(app, None)?,
+        ],
+    )?;
+    Ok(Menu::with_items(app, &[&file, &edit])?)
 }
 
 /// Builds the tray icon/menu and returns the autostart toggle's

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -23,11 +23,33 @@ pub const MENU_QUIT: &str = "quit";
 /// macOS-only — see the `set_menu()` callsite in lib.rs for why.
 #[cfg(target_os = "macos")]
 pub fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+    // The first submenu becomes the macOS application menu (its name is
+    // replaced by the app name). It must carry the standard roles — the
+    // Quit role in particular is what binds ⌘Q (key equivalent "q" + the
+    // terminate: selector); without it Cmd+Q is bound to nothing and the
+    // shortcut silently does nothing. Quitting then funnels into Tauri's
+    // ExitRequested flow, where lib.rs tears the server down.
+    let app_menu = Submenu::with_items(
+        app,
+        "DeepSeek Harness",
+        true,
+        &[
+            &PredefinedMenuItem::about(app, None, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::hide(app, None)?,
+            &PredefinedMenuItem::hide_others(app, None)?,
+            &PredefinedMenuItem::show_all(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::quit(app, None)?,
+        ],
+    )?;
     let open_browser = MenuItem::with_id(app, MENU_OPEN_BROWSER, "在浏览器中打开", true, None::<&str>)?;
     let restart = MenuItem::with_id(app, MENU_RESTART, "重启服务", true, None::<&str>)?;
     let open_data_dir = MenuItem::with_id(app, MENU_OPEN_DATA_DIR, "打开数据目录 (~/.dsh)", true, None::<&str>)?;
-    let quit = MenuItem::with_id(app, MENU_QUIT, "退出", true, None::<&str>)?;
-    let file = Submenu::with_items(app, "文件", true, &[&open_browser, &restart, &open_data_dir, &quit])?;
+    // The custom "退出" item is gone: the app menu's standard Quit role
+    // covers quitting (with the ⌘Q shortcut), and tearing the server down
+    // happens once in lib.rs's ExitRequested handler for every quit path.
+    let file = Submenu::with_items(app, "文件", true, &[&open_browser, &restart, &open_data_dir])?;
     // macOS 上 Cmd+C / Cmd+V / Cmd+X / Cmd+A 等快捷键必须由菜单中的标准
     // "编辑"项提供（通过 responder chain 分发到 WebView），缺少它们会导致
     // 剪切/复制/粘贴失效。PredefinedMenuItem 的角色项会自动带上正确的
@@ -46,7 +68,21 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             &PredefinedMenuItem::select_all(app, None)?,
         ],
     )?;
-    Ok(Menu::with_items(app, &[&file, &edit])?)
+    // Standard Window roles give back ⌘M (minimize) and ⌘W (close window —
+    // which this app's tray-resident design turns into hide). Without them
+    // those shortcuts are dead for the same reason ⌘Q was.
+    let window = Submenu::with_items(
+        app,
+        "窗口",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+    Ok(Menu::with_items(app, &[&app_menu, &file, &edit, &window])?)
 }
 
 /// Builds the tray icon/menu and returns the autostart toggle's


### PR DESCRIPTION
## Problem

On macOS the menu bar was missing every standard role item, which breaks platform conventions in user-visible ways:

- **⌘C / ⌘V / ⌘X / ⌘A silently do nothing** — the WebView has no responder chain for cut/copy/paste/select-all unless a menu provides them.
- **⌘Q silently does nothing** — macOS only dispatches ⌘Q through the app menu's standard Quit item (`terminate:` selector + `q` key equivalent). The custom 退出 item carries no key equivalent, so the shortcut is bound to nothing.
- Same story for ⌘M (minimize) and ⌘W (close window), and there is no About/Hide in the menu bar at all.

## Fix

Build the standard macOS menu-bar structure from `PredefinedMenuItem` roles:

1. **Application menu** (first submenu): About, Hide, Hide Others, Show All, Quit.
2. **文件**: unchanged (open in browser / restart / data dir); the custom 退出 item is removed in favor of the standard Quit role.
3. **编辑**: undo/redo/cut/copy/paste/select-all.
4. **窗口** (new): minimize / maximize / close-window.

Because the predefined Quit role does not route through `on_menu_event`, the spawned dsh server is now torn down in a `RunEvent::ExitRequested` handler at the end of `run()` — the single exit path covering the ⌘Q role, the tray 退出 item and updater restarts (previously only the tray path stopped the server).

Note: ⌘W closing the window keeps the existing tray-resident behavior (window hides, server keeps running) — that is this app's designed close semantics.

## Tested

macOS release build: ⌘C/⌘V/⌘X/⌘A, ⌘Q, ⌘M, ⌘W all behave as described; quitting via ⌘Q also stops a spawned harness server (no orphaned process).
