### PR TITLE
feat(macos): restore the native title bar (traffic lights + drag)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -611,6 +611,18 @@ pub fn run() {
                 install_external_link_handlers(&handle, &win);
             }
 
+            // `decorations: false` in tauri.conf.json gives the frameless
+            // Windows/Linux look (custom in-page buttons + drag region), but
+            // macOS users expect the native title bar — real traffic lights
+            // on the left and drag-to-move for free. Restore it there; the
+            // shell page mirrors this compile-time platform split in
+            // ui/app.js (IS_MACOS) by hiding its custom window controls and
+            // dropping the toolbar drag region.
+            #[cfg(target_os = "macos")]
+            if let Some(win) = app.get_webview_window("main") {
+                win.set_decorations(true)?;
+            }
+
             // A window/app menu set via `set_menu()` becomes the global
             // top-of-screen menu bar on macOS (platform convention, doesn't
             // cost window space) but a classic in-window Win32-style menu

--- a/ui/app.js
+++ b/ui/app.js
@@ -35,6 +35,8 @@ const els = {
   panelCards: document.getElementById("panel-cards"),
   resizePanelCards: document.getElementById("resize-panel-cards"),
   btnToolbarFiles: document.getElementById("btn-toolbar-files"),
+  toolbar: document.getElementById("toolbar"),
+  windowControls: document.getElementById("window-controls"),
   btnWinMinimize: document.getElementById("btn-win-minimize"),
   btnWinMaximize: document.getElementById("btn-win-maximize"),
   btnWinClose: document.getElementById("btn-win-close"),
@@ -136,18 +138,39 @@ async function refresh() {
   }
 }
 
-// ── window controls (frameless window) ──────────────────────────────────
+// ── window chrome (per-platform) ────────────────────────────────────────
 //
-// decorations:false in tauri.conf.json removes the OS title bar entirely;
-// #toolbar carries data-tauri-drag-region (see index.html) so its own empty
-// space still moves the window, and these three buttons stand in for the
-// native minimize/maximize/close the OS would otherwise have drawn.
+// decorations:false in tauri.conf.json removes the OS title bar on every
+// platform. On Windows/Linux the shell keeps that frameless look: #toolbar
+// carries data-tauri-drag-region (see index.html) so its own empty space
+// moves the window, and the three custom buttons below stand in for the
+// native minimize/maximize/close. On macOS lib.rs re-enables the native
+// title bar (real traffic lights on the left, native drag), so the custom
+// replacements are hidden and the toolbar stops acting as a drag region —
+// see initWindowChrome() below.
 // lib.rs's on_window_event CloseRequested handler (hide-to-tray) is keyed
 // off the window-close request itself, not off which button drew it — so
 // appWindow.close() below re-enters that exact same Rust-side path with
 // nothing to change there.
 
 const appWindow = getCurrentWindow();
+
+// Mirrors lib.rs's compile-time `#[cfg(target_os = "macos")]` decorations
+// split. The UA is deterministic at load time, unlike querying isDecorated()
+// which could race with the Rust-side set_decorations(true) during setup.
+const IS_MACOS = navigator.userAgent.includes("Macintosh");
+
+function initWindowChrome() {
+  if (!IS_MACOS) return;
+  // Native title bar takes over window dragging and min/max/close — the
+  // custom replacements would only duplicate it (and its drag region would
+  // fight the native double-click-to-zoom on the title bar).
+  els.windowControls.classList.add("hidden");
+  els.toolbar.removeAttribute("data-tauri-drag-region");
+  // Left-align the remaining toolbar actions like a standard macOS toolbar
+  // (see styles.css body.platform-decorated).
+  document.body.classList.add("platform-decorated");
+}
 
 const ICON_MAXIMIZE =
   '<svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true"><rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor"/></svg>';
@@ -833,7 +856,10 @@ async function init() {
   applyCardFileHeight();
   initCardsResizeHandle();
   syncCardResizeHandleVisibility();
-  initWindowControls();
+  initWindowChrome();
+  // macOS uses the native title bar buttons; the custom ones are hidden
+  // (and would only double up with the native traffic lights).
+  if (!IS_MACOS) initWindowControls();
 
   try {
     const info = await invoke("get_info");

--- a/ui/app.js
+++ b/ui/app.js
@@ -161,15 +161,22 @@ const appWindow = getCurrentWindow();
 const IS_MACOS = navigator.userAgent.includes("Macintosh");
 
 function initWindowChrome() {
-  if (!IS_MACOS) return;
-  // Native title bar takes over window dragging and min/max/close — the
-  // custom replacements would only duplicate it (and its drag region would
-  // fight the native double-click-to-zoom on the title bar).
-  els.windowControls.classList.add("hidden");
-  els.toolbar.removeAttribute("data-tauri-drag-region");
-  // Left-align the remaining toolbar actions like a standard macOS toolbar
-  // (see styles.css body.platform-decorated).
-  document.body.classList.add("platform-decorated");
+  // #window-controls is hidden by default in index.html so it can never
+  // paint before this decision runs — on macOS the native traffic lights
+  // take over, and a cold-start frame with BOTH the native lights and the
+  // custom buttons would otherwise flash. Only the frameless Windows/Linux
+  // chrome reveals the custom controls.
+  if (IS_MACOS) {
+    // Native title bar takes over window dragging and min/max/close — the
+    // custom replacements would only duplicate it (and its drag region would
+    // fight the native double-click-to-zoom on the title bar).
+    els.toolbar.removeAttribute("data-tauri-drag-region");
+    // Left-align the remaining toolbar actions like a standard macOS toolbar
+    // (see styles.css body.platform-decorated).
+    document.body.classList.add("platform-decorated");
+  } else {
+    els.windowControls.classList.remove("hidden");
+  }
 }
 
 const ICON_MAXIMIZE =

--- a/ui/index.html
+++ b/ui/index.html
@@ -58,8 +58,11 @@
         width) moves the window, replacing the OS title bar — see
         #window-controls below for its replacement minimize/maximize/close.
         On macOS lib.rs restores the native title bar, so app.js strips the
-        drag region and hides those custom controls at runtime (native
-        traffic lights + title-bar drag take over).
+        drag region and leaves those custom controls hidden (native traffic
+        lights + title-bar drag take over). #window-controls starts hidden
+        in the markup itself so it can never paint alongside the native
+        traffic lights before app.js has decided which chrome to use — it
+        is revealed only on the frameless platforms.
 
         A direct child of #app-shell (not nested inside the row below), so
         it always spans the full window width regardless of whether the
@@ -78,7 +81,7 @@
             <svg class="icon"><use href="#icon-folder"></use></svg>
           </button>
         </div>
-        <div id="window-controls">
+        <div id="window-controls" class="hidden">
           <button id="btn-win-minimize" class="window-btn" title="最小化">
             <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
               <path d="M0 5h10" stroke="currentColor" stroke-width="1" />

--- a/ui/index.html
+++ b/ui/index.html
@@ -53,10 +53,13 @@
       <!--
         No brand lockup here on purpose — the iframed harness content
         already renders its own logo/title, so the shell chrome doesn't
-        repeat it. data-tauri-drag-region makes this bar's own empty space
-        (most of its width) move the window, replacing the OS title bar
-        decorations:false removes — see #window-controls below for its
-        replacement minimize/maximize/close.
+        repeat it. On Windows/Linux (frameless: decorations:false) this bar
+        carries data-tauri-drag-region so its own empty space (most of its
+        width) moves the window, replacing the OS title bar — see
+        #window-controls below for its replacement minimize/maximize/close.
+        On macOS lib.rs restores the native title bar, so app.js strips the
+        drag region and hides those custom controls at runtime (native
+        traffic lights + title-bar drag take over).
 
         A direct child of #app-shell (not nested inside the row below), so
         it always spans the full window width regardless of whether the

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -84,10 +84,13 @@ body {
 /* ── toolbar: drag region + right-aligned dock/window-control buttons ── */
 /*
    No brand block anymore (the iframed harness already shows its own
-   logo/title — see the HTML comment above #toolbar), so this bar has a
-   single cluster on the right and an otherwise-empty data-tauri-drag-region
-   everywhere else, replacing the OS title bar that decorations:false in
-   tauri.conf.json removes.
+   logo/title — see the HTML comment above #toolbar), so on the frameless
+   Windows/Linux build this bar has a single cluster on the right and an
+   otherwise-empty data-tauri-drag-region everywhere else, replacing the OS
+   title bar that decorations:false in tauri.conf.json removes. On macOS the
+   native title bar is restored in lib.rs — see body.platform-decorated
+   below, which left-aligns the actions and lets app.js hide the custom
+   window controls.
 */
 
 #toolbar {
@@ -98,6 +101,13 @@ body {
   padding: 10px 14px;
   background: var(--sidebar-bg);
   border-bottom: 1px solid var(--card-border);
+}
+
+/* macOS restores the native title bar (see app.js's initWindowChrome), so
+   the toolbar keeps only its left action cluster and lays it out like a
+   standard macOS toolbar; the custom window controls are hidden there. */
+body.platform-decorated #toolbar {
+  justify-content: flex-start;
 }
 
 #toolbar-actions {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -89,8 +89,9 @@ body {
    otherwise-empty data-tauri-drag-region everywhere else, replacing the OS
    title bar that decorations:false in tauri.conf.json removes. On macOS the
    native title bar is restored in lib.rs — see body.platform-decorated
-   below, which left-aligns the actions and lets app.js hide the custom
-   window controls.
+   below, which left-aligns the actions; the custom window controls start
+   hidden in the markup and are only revealed on the frameless platforms
+   (see index.html / app.js initWindowChrome).
 */
 
 #toolbar {


### PR DESCRIPTION
## Problem

`decorations: false` in `tauri.conf.json` removes the OS title bar on every platform. On macOS that leaves the Windows-style right-aligned minimize/maximize/close buttons and no way to drag the window — neither matches macOS conventions.

## Change

- macOS only (compile-time `cfg` in `lib.rs`): re-enable native window decorations at setup, bringing back the real traffic lights (top-left), native drag-to-move and double-click-to-zoom.
- The shell page mirrors the same platform split (`IS_MACOS` in `ui/app.js`, UA-based so it cannot race the Rust-side `set_decorations` during load): hides the custom window controls, stops treating the toolbar as a drag region, and left-aligns the remaining toolbar actions like a standard macOS toolbar.
- Windows/Linux keep the frameless custom chrome unchanged.

## Note

This is a design decision — if you prefer keeping the custom chrome on macOS too, feel free to say so; the independent drag-permission fix is submitted separately so it is not blocked by this choice.
