### PR TITLE
feat: route file-mention clicks in the harness iframe to the dock preview

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -385,6 +385,81 @@ fn disable_devtools(win: &tauri::WebviewWindow) {
 #[cfg(not(all(windows, not(debug_assertions))))]
 fn disable_devtools(_win: &tauri::WebviewWindow) {}
 
+/// Intercepts clicks on the harness's own file-mention buttons (e.g. a
+/// message referencing `index.html` renders one inline) and redirects them
+/// into this shell's own file dock instead of their default "open" action.
+///
+/// The harness is a plain remote page with no Tauri IPC access (see the
+/// module doc comment) and ships no `postMessage` channel of its own to
+/// piggyback on (see `panel.rs`'s "active workspace" section) — its source
+/// (`deepseek-ai/deepseek-harness`) isn't part of this repo either, so
+/// there's no click handler here to edit directly. `AddScriptToExecuteOnDocumentCreated`
+/// runs in every document WebView2 creates, including this iframe's, which
+/// makes the origin boundary a non-issue: the script executes as same-origin
+/// content of the page it's injected into, same as the harness's own
+/// scripts, and the resulting `postMessage` is exactly the kind of
+/// cross-origin signal that boundary was always meant to allow through —
+/// nothing here grants the harness page any *new* capability (no IPC, no
+/// filesystem access), it only ever gets to ask its own parent window to
+/// open something the parent already has every right to open.
+///
+/// Matched on `aria-label`/`title` shape (a "打开 <path>" label alongside a
+/// `title` holding that same absolute path) rather than the button's CSS
+/// class: that class is bundler-hashed (CSS Modules) and free to change on
+/// every harness rebuild, while the label text is the actual user-facing
+/// contract. Capture-phase so this runs before the harness's own click
+/// handler on the same button can act — `stopPropagation` then keeps that
+/// handler from ever seeing the event at all, not just from acting after us.
+#[cfg(windows)]
+fn inject_file_mention_bridge(win: &tauri::WebviewWindow) {
+    use webview2_com::AddScriptToExecuteOnDocumentCreatedCompletedHandler;
+    use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
+    use windows::core::HSTRING;
+
+    const SCRIPT: &str = r#"(function () {
+  if (window.top === window) return;
+  document.addEventListener(
+    "click",
+    function (event) {
+      var el = event.target;
+      while (el && el !== document.body) {
+        if (el.tagName === "BUTTON") {
+          var label = el.getAttribute("aria-label") || "";
+          var path = el.getAttribute("title") || "";
+          if (label.indexOf("打开 ") === 0 && path) {
+            event.preventDefault();
+            event.stopPropagation();
+            window.top.postMessage({ source: "dsh-desktop", type: "open-file-mention", path: path }, "*");
+            return;
+          }
+        }
+        el = el.parentElement;
+      }
+    },
+    true,
+  );
+})();"#;
+
+    let _ = win.with_webview(|webview| {
+        let controller: ICoreWebView2Controller = webview.controller();
+        let result: webview2_com::Result<()> = (|| {
+            let core = unsafe { controller.CoreWebView2() }?;
+            AddScriptToExecuteOnDocumentCreatedCompletedHandler::wait_for_async_operation(
+                Box::new(move |handler| unsafe {
+                    core.AddScriptToExecuteOnDocumentCreated(&HSTRING::from(SCRIPT), &handler)
+                        .map_err(Into::into)
+                }),
+                Box::new(|_result, _id| Ok(())),
+            )
+        })();
+        if let Err(e) = result {
+            eprintln!("[dsh-desktop] failed to inject file-mention bridge script: {e}");
+        }
+    });
+}
+#[cfg(not(windows))]
+fn inject_file_mention_bridge(_win: &tauri::WebviewWindow) {}
+
 // ── menu / tray actions ──────────────────────────────────────────────────────
 
 fn handle_menu_action(app: &AppHandle, id: &str) {
@@ -524,6 +599,7 @@ pub fn run() {
                 disable_context_menu(&win);
                 disable_zoom_control(&win);
                 disable_devtools(&win);
+                inject_file_mention_bridge(&win);
             }
 
             // A window/app menu set via `set_menu()` becomes the global

--- a/ui/app.js
+++ b/ui/app.js
@@ -825,6 +825,114 @@ async function refreshPanel() {
 // whole lifetime.
 const PANEL_POLL_MS = 6000;
 
+// ── file-mention bridge (harness iframe → dock) ─────────────────────────
+//
+// lib.rs's inject_file_mention_bridge injects a capture-phase click
+// listener directly into the harness iframe's document (WebView2's
+// AddScriptToExecuteOnDocumentCreated) — the harness itself has no
+// postMessage channel of its own and isn't this repo's source to add one
+// to. That injected script intercepts a file-mention button's default
+// "open" action and posts {source:"dsh-desktop", type:"open-file-mention",
+// path: "<absolute path>"} to window.top instead. This listener is the
+// other end of that bridge.
+//
+// The path arrives absolute (it's the button's own title attribute, an OS
+// path), but every panel command (get_workspace_tree/get_editable_preview/…)
+// takes a path relative to whichever workspace root is active — see
+// get_editable_preview's doc comment in lib.rs. So the workspace the file
+// belongs to has to be resolved here, from the absolute path, before
+// showPreview can be called at all.
+
+function normalizeForCompare(p) {
+  return p.replace(/\\/g, "/").toLowerCase();
+}
+
+// Longest-root-prefix wins, so a workspace nested inside another workspace's
+// directory (however unusual) still resolves to the more specific one
+// rather than whichever happened to come first in the list.
+function resolveWorkspaceForPath(knownWorkspaces, absPath) {
+  const target = normalizeForCompare(absPath);
+  let best = null;
+  for (const ws of knownWorkspaces) {
+    const root = normalizeForCompare(ws.path).replace(/\/+$/, "");
+    if (target === root || target.startsWith(root + "/")) {
+      if (!best || root.length > normalizeForCompare(best.path).length) best = ws;
+    }
+  }
+  return best;
+}
+
+// Same persistence side effects as the manual workspace picker's own change
+// handler above — just driven programmatically instead of by a user
+// selecting an <option>. Deliberately skips that handler's own
+// confirmDiscardIfNeeded() gate: showPreview() (called right after by
+// handleFileMention) already runs that same check against the file this
+// click is actually trying to open, so gating here too would just ask twice
+// for one discard decision.
+function lockWorkspace(path) {
+  lockedWorkspace = path;
+  localStorage.setItem(LOCKED_WORKSPACE_KEY, path);
+  els.panelWorkspaceSelect.value = path;
+}
+
+// Reveals a just-selected tree row: expands every collapsed ancestor
+// (renderTreeNode's own hasChildren click handler is the only thing that
+// ever collapses one — a user fold from an earlier look at the tree) so the
+// row is actually in the visible/scrollable flow, not sitting inside a
+// display:none .tree-children, then scrolls it into view.
+function revealSelectedTreeRow() {
+  const row = els.panelTree.querySelector(".tree-row-selected");
+  if (!row) return;
+  let node = row.parentElement;
+  while (node && node !== els.panelTree) {
+    if (node.classList.contains("tree-children")) {
+      node.classList.remove("collapsed");
+      const caretRow = node.previousElementSibling;
+      if (caretRow) caretRow.classList.add("tree-expanded");
+    }
+    node = node.parentElement;
+  }
+  row.scrollIntoView({ block: "nearest" });
+}
+
+async function handleFileMention(absPath) {
+  setDockOpen(true);
+
+  const knownWorkspaces = await invoke("get_known_workspaces").catch(() => []);
+  const workspace = resolveWorkspaceForPath(knownWorkspaces, absPath);
+  if (!workspace) {
+    // No known workspace claims this path — nothing to lock onto or
+    // convert a relative path against; surface it the same way an
+    // unreadable preview already does rather than silently doing nothing.
+    els.panelPreviewTitle.textContent = absPath;
+    els.panelPreviewTitle.title = absPath;
+    els.cardFile.classList.remove("hidden");
+    els.panelPreviewBody.textContent = "该文件不属于任何已知工作区";
+    return;
+  }
+
+  const root = workspace.path.replace(/\\/g, "/").replace(/\/+$/, "");
+  const relPath = absPath.replace(/\\/g, "/").slice(root.length).replace(/^\/+/, "");
+
+  if (workspace.path !== lockedWorkspace) {
+    lockWorkspace(workspace.path);
+  }
+  await refreshTreeAndGitStatus();
+  await showPreview(relPath);
+  revealSelectedTreeRow();
+}
+
+window.addEventListener("message", (event) => {
+  // Only the harness iframe itself is a legitimate sender — the injected
+  // script runs inside that document and nowhere else, and nothing else in
+  // this page's world has a reason to post this message shape.
+  if (event.source !== els.harnessFrame.contentWindow) return;
+  const data = event.data;
+  if (!data || data.source !== "dsh-desktop" || data.type !== "open-file-mention") return;
+  if (typeof data.path !== "string" || !data.path) return;
+  handleFileMention(data.path);
+});
+
 // ── init ─────────────────────────────────────────────────────────────────
 
 async function init() {

--- a/ui/app.js
+++ b/ui/app.js
@@ -309,11 +309,18 @@ function initCardsResizeHandle() {
 // deliberate opt-in each session, not a state to restore. Only the width
 // (once opened) is remembered, via panelWidth/PANEL_WIDTH_KEY above.
 
-function setDockOpen(open) {
+// `refresh: false` lets a caller that's about to drive its own, carefully
+// ordered refresh (see handleFileMention) show the dock without also
+// kicking off this function's own un-awaited refreshPanel() — two
+// concurrent, uncoordinated tree renders racing against each other, one of
+// which could win before the caller's own state (e.g. currentPreviewPath)
+// is actually set, would put the exact same stale-selection race right back
+// after fixing it in the caller.
+function setDockOpen(open, { refresh = true } = {}) {
   els.panel.classList.toggle("hidden", !open);
   els.resizePanelContent.classList.toggle("hidden", !open);
   els.btnToolbarFiles.classList.toggle("active", open);
-  if (open) refreshPanel();
+  if (open && refresh) refreshPanel();
 }
 
 function toggleDock() {
@@ -896,7 +903,7 @@ function revealSelectedTreeRow() {
 }
 
 async function handleFileMention(absPath) {
-  setDockOpen(true);
+  setDockOpen(true, { refresh: false });
 
   const knownWorkspaces = await invoke("get_known_workspaces").catch(() => []);
   const workspace = resolveWorkspaceForPath(knownWorkspaces, absPath);
@@ -904,6 +911,12 @@ async function handleFileMention(absPath) {
     // No known workspace claims this path — nothing to lock onto or
     // convert a relative path against; surface it the same way an
     // unreadable preview already does rather than silently doing nothing.
+    // Tears down whatever was previously open the same way closePreview()
+    // does — otherwise a stale editor instance (and its currentPreviewPath)
+    // would linger and get silently re-fetched/re-mounted by the next poll,
+    // clobbering this error message with unrelated old content.
+    currentPreviewPath = null;
+    destroyEditor();
     els.panelPreviewTitle.textContent = absPath;
     els.panelPreviewTitle.title = absPath;
     els.cardFile.classList.remove("hidden");
@@ -917,8 +930,14 @@ async function handleFileMention(absPath) {
   if (workspace.path !== lockedWorkspace) {
     lockWorkspace(workspace.path);
   }
-  await refreshTreeAndGitStatus();
+  // showPreview() must land first — it's the only place that sets
+  // currentPreviewPath, and renderTreeNode (inside refreshTreeAndGitStatus)
+  // marks .tree-row-selected by comparing against that same value. Doing
+  // this in the other order renders the tree against whatever was
+  // *previously* open, so revealSelectedTreeRow() below would find a stale
+  // row (or none at all) instead of the file this click just opened.
   await showPreview(relPath);
+  await refreshTreeAndGitStatus();
   revealSelectedTreeRow();
 }
 


### PR DESCRIPTION
## Summary
- The harness's own file-mention buttons (e.g. `index.html` chips in a chat message) open the file in the system browser by default. The harness is a remote page with no Tauri IPC access and isn't this repo's source to edit, so its click handler can't be changed directly.
- A WebView2 `AddScriptToExecuteOnDocumentCreated` hook (`inject_file_mention_bridge`, alongside the existing `disable_context_menu`/`disable_zoom_control`/`disable_devtools` hooks) injects a capture-phase click interceptor into the harness iframe's own document. It matches buttons by `aria-label`/`title` shape (not the bundler-hashed CSS class, which changes across harness rebuilds), blocks the default open action, and posts the absolute file path to the parent window.
- The shell (`ui/app.js`) listens for that message (validated against `event.source`), opens the file dock regardless of prior state, resolves which known workspace the absolute path belongs to (longest-root-prefix match) and switches to it, expands any collapsed ancestor folders in the tree and scrolls the file into view, then loads it via the existing `showPreview()`.

## Test plan
- [x] `cargo check` passes
- [x] `node --check ui/app.js` passes
- [x] Manually verified in a local debug build (`cargo build`, `target/debug/dsh-desktop.exe`): clicking a file-mention button now opens the dock, switches to the owning project, reveals and previews the file — no more fallthrough to the system browser