### PR TITLE
fix: run the user's login shell in the terminal on macOS/Linux

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -22,12 +22,37 @@ struct TerminalSession {
 #[derive(Default)]
 pub struct TerminalState(Mutex<Option<TerminalSession>>);
 
-/// `cmd.exe` via `%COMSPEC%` — present on every Windows install without
-/// depending on PowerShell being on `PATH`; a user who wants pwsh can just
-/// type it once the shell is up.
+/// The shell the dock terminal runs.
+///
+/// Windows: `cmd.exe` via `%COMSPEC%` — present on every Windows install
+/// without depending on PowerShell being on `PATH`; a user who wants pwsh
+/// can just type it once the shell is up.
+///
+/// macOS/Linux: the user's login shell (`$SHELL`), run with `-l` so the
+/// profile chain executes (`path_helper` on macOS pulls Homebrew etc. into
+/// `PATH` — the GUI app itself inherits the minimal Finder PATH). Spawning
+/// `cmd.exe` here is what produced "Unable to spawn cmd.exe…" on macOS.
+#[cfg(target_os = "windows")]
 fn shell_command() -> CommandBuilder {
     let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".into());
     CommandBuilder::new(shell)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn shell_command() -> CommandBuilder {
+    let shell = std::env::var("SHELL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "macos") {
+                "/bin/zsh".into()
+            } else {
+                "/bin/bash".into()
+            }
+        });
+    let mut cmd = CommandBuilder::new(shell);
+    cmd.arg("-l");
+    cmd
 }
 
 /// Reads PTY output on a background thread for as long as the session


### PR DESCRIPTION
## Problem

On macOS, opening the dock terminal fails with:

```
终端启动失败: Unable to spawn cmd.exe because: No viable candidates found in PATH "/usr/bin:/bin:/usr/sbin:/sbin"
```

`shell_command()` hardcodes `COMSPEC`/`cmd.exe` — the Windows-only default shell — so the terminal is unusable on macOS/Linux.

## Fix

Split by platform:

- **Windows**: unchanged — `cmd.exe` via `%COMSPEC%`.
- **macOS/Linux**: spawn `$SHELL` (falling back to `/bin/zsh` on macOS, `/bin/bash` on Linux) with `-l` so the login-shell profile chain executes. That matters on macOS in particular: `path_helper` runs from `/etc/zprofile` and pulls Homebrew and other user toolchains into `PATH`, which the GUI app itself lacks when launched from Finder (inheriting only `/usr/bin:/bin:/usr/sbin:/sbin`).

## Tested

- `cargo check` clean on macOS.
- Manual verification pending on the user's machine (spawns zsh login shell in the dock terminal).
