### PR TITLE
fix: don't steal focus on single-instance relaunch when window is visible

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -325,6 +325,39 @@ fn show_main_window(app: &AppHandle) {
     }
 }
 
+/// Single-instance relaunch path (second launch attempt while the app is
+/// already running). Unlike the tray/hotkey callers, this is *not* a user
+/// summoning the window on purpose — it fires for any duplicate launch,
+/// including one this app didn't ask for (a stale launcher, a file
+/// association, an autostart job). Showing + focusing unconditionally then
+/// yanks the window to the front and steals focus from whatever the user is
+/// doing in another app.
+///
+/// So: only summon the window when it isn't already on screen. If it is
+/// visible and not minimized, leave it completely alone. If it was hidden
+/// to the tray or minimized, surface it normally — that's what a user who
+/// re-launches the app wants. Same thread discipline as `show_main_window`
+/// (window APIs must run on the main/event-loop thread).
+fn show_main_window_on_relaunch(app: &AppHandle) {
+    let app_in_closure = app.clone();
+    let result = app.run_on_main_thread(move || {
+        let app = app_in_closure;
+        if let Some(win) = app.get_webview_window("main") {
+            match (win.is_visible(), win.is_minimized()) {
+                (Ok(true), Ok(false)) => {
+                    // Already on screen — do nothing, don't steal focus.
+                }
+                _ => show_main_window(&app),
+            }
+        } else {
+            eprintln!("[dsh-desktop] show_main_window_on_relaunch: no window labeled \"main\"");
+        }
+    });
+    if let Err(e) = result {
+        eprintln!("[dsh-desktop] show_main_window_on_relaunch: run_on_main_thread failed: {e}");
+    }
+}
+
 /// Disables WebView2's built-in right-click context menu (Back / Forward /
 /// Reload / Inspect / …). The harness page is a plain remote page with no
 /// Tauri-side navigation UI of its own, so that default menu was the only
@@ -687,7 +720,10 @@ pub fn run() {
                 let app2 = app.clone();
                 thread::spawn(move || server::restart(&app2, &srv));
             }
-            show_main_window(app);
+            // Don't steal focus when the window is already on screen (e.g. a
+            // stale launcher re-fires a duplicate launch while the user is
+            // working elsewhere) — see show_main_window_on_relaunch.
+            show_main_window_on_relaunch(app);
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -719,11 +719,20 @@ pub fn run() {
                 let srv = state.server.clone();
                 let app2 = app.clone();
                 thread::spawn(move || server::restart(&app2, &srv));
+                // A workspace switch is a deliberate summon (the user just
+                // picked a folder to open), same as the tray click/hotkey —
+                // always surface it so they see the switch happen, even if
+                // the window was technically "visible" but buried behind
+                // other windows or on another virtual desktop.
+                show_main_window(app);
+            } else {
+                // No workspace arg: an untargeted duplicate launch (desktop
+                // icon, Start menu, or something this app didn't ask for —
+                // a stale launcher, autostart job). Don't steal focus when
+                // the window is already on screen — see
+                // show_main_window_on_relaunch.
+                show_main_window_on_relaunch(app);
             }
-            // Don't steal focus when the window is already on screen (e.g. a
-            // stale launcher re-fires a duplicate launch while the user is
-            // working elsewhere) — see show_main_window_on_relaunch.
-            show_main_window_on_relaunch(app);
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())


### PR DESCRIPTION
## Problem

A duplicate launch of the app (desktop icon, Start menu, a stale launcher or autostart job re-firing the app) hits the `tauri_plugin_single_instance` relaunch callback, which unconditionally calls `show_main_window()` — `show()` + `unminimize()` + `set_focus()`. When the window is already on screen and the user is working in another app, this yanks the window to the front and steals focus from whatever they were doing. (This surfaced in practice when a leftover launchd job kept re-launching the app every few minutes.)

## Fix

Add `show_main_window_on_relaunch()` and use it from the single-instance callback:

- If the window is **visible and not minimized** → do nothing, never steal focus.
- If it was **hidden to the tray or minimized** → surface it as before (that's what a user re-launching the app wants).

The tray "显示窗口" action and the global hotkey keep their original always-show-and-focus behavior — those are deliberate user summons. Only the passive relaunch path is made non-intrusive.

Window state queries run on the main thread via `run_on_main_thread`, same discipline as `show_main_window`. A failed visibility probe falls back to the old summon behavior rather than leaving the window hidden.

## Test plan

- [x] `cargo check` passes
- [ ] Manual: window visible + in another app → duplicate launch → window stays put, no focus steal
- [ ] Manual: window hidden to tray → duplicate launch → window reappears and focuses
