### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui"


### PR DESCRIPTION
## Summary
- Version bump 1.4.0 → 1.4.1 covering everything merged since the last release: plugin market star-count sort + centered titlebar tagline (#19), WebView2 clipboard permission fix (#20), single-instance-relaunch focus-steal fix (#17), login-shell-in-terminal fix on macOS/Linux (#16), and the EADDRINUSE re-probe robustness fix (#9).

## Test plan
- [x] Version numbers match in package.json and src-tauri/tauri.conf.json
- [ ] CI release workflow builds and drafts the release once tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)