### PR TITLE
fix: native shell (tray/menu/boot screen/dock) now respects OS language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Tauri（Rust + WebView2）桌面壳，托管 `@deepseek-ai/dsh` 的 `dsh web` �
 - **`docs/DEVELOPMENT.md` 里写的环境变量覆盖项（`DSH_DESKTOP_NODE`/`DSH_DESKTOP_DSH_BIN`/`DSH_DESKTOP_RUNTIME_DIR` 等）是诊断"找不到 node/dsh"类问题时的第一入口**，不要在 `resolve_node`/`resolve_bin` 之外另起一套定位逻辑。
 - **测试原生窗口时，关闭方式必须带上子进程清理。** `taskkill` 要 `/F /T`（不带 `/T` 会留下孤儿 `dsh` Node 服务，下次重新编译/启动时可能撞端口冲突或读到脏状态）。
 - **手动验证原生窗口界面的改动（截图、点击、拖拽）应该让用户直接在真实窗口里操作确认，不要依赖自动化工具反复截图/读无障碍树来回合调试。** 桌面自动化对这个项目某些原生窗口的截图本身不可靠（历史上记录过纯黑图），反复来回的诊断成本远高于直接问用户"你看到的是什么"。
+- **原生 shell 的 zh/en 双语（`i18n.rs` + `ui/app.js` 里的 `STRINGS`/`t()`）跟 `dsh web`（iframe 里的网页）自己的 `locale.preference` 设置是两套完全独立、互不感知的机制，不是同一个开关。** 两边各自从系统/浏览器语言探测一次（Rust 侧 `sys_locale::get_locale()`，JS 侧 `navigator.language`），规则一致（探测到 `en*` 才用英文，其余一律回退中文），但没有任何代码把二者同步在一起——iframe 里的网页是完全隔离的远程页面，永远没有 Tauri IPC（见 `lib.rs` 顶部模块注释），这层壳读不到它的 `locale.preference`，也不该为此专门开一个通信通道。想要"跟随应用内语言设置"是行不通的；如果这个假设第二次被提出，说明这条边界需要重新在这里写清楚，而不是去改代码硬凑。
 
 ## 插件市场（`ui/app.js` 里 `plugin-market-*`，`server.rs` 里 `install_plugin`/`check_pnpm_available`/`install_pnpm`）
 
@@ -47,5 +48,6 @@ Tauri（Rust + WebView2）桌面壳，托管 `@deepseek-ai/dsh` 的 `dsh web` �
 - `src-tauri/src/panel.rs` — 右侧文件面板的文件树/Git 状态/编辑保存
 - `src-tauri/src/menu.rs` — 原生菜单栏 + 托盘
 - `src-tauri/src/terminal.rs` — 内嵌终端（ConPTY/winpty）
+- `src-tauri/src/i18n.rs` — 原生 shell（菜单/托盘/通知/少量错误提示）的 zh/en 探测与翻译，`ui/app.js` 里的 `STRINGS`/`t()` 是同一套规则在前端的独立实现
 - `ui/app.js` — 唯一的前端逻辑文件，启动页状态机、dock 面板、CodeMirror 编辑器、终端 xterm.js、插件市场全在这一个文件里
 - `docs/internal/HANDOFF.md` — 最近一轮开发的交接记录，每轮重写，读之前先看 git log 确认没有更新的版本

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
+ "sys-locale",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -3842,6 +3843,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,11 @@ portable-pty = "0.9"
 # control/partial-UTF-8 bytes directly, and this sidesteps that instead of
 # hand-rolling the escaping.
 base64 = "0.22"
+# OS UI-language detection for the native shell's zh/en strings (i18n.rs) —
+# the same crate tauri-plugin-os itself uses internally for its `locale()`
+# command, pulled in directly since only the native (non-JS) side needs it
+# here.
+sys-locale = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 # Raw WebView2 settings access (disabling the default context menu) —

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -1,0 +1,45 @@
+//! Bilingual (zh/en) strings for the native shell: tray, native menu bar
+//! (macOS), OS notifications, and the handful of `Result<_, String>` errors
+//! that surface directly in the boot/error screen or the plugin-install log
+//! (see `ui/app.js`'s own `STRINGS`/`t()` for the frontend half of this same
+//! split — it detects locale independently, client-side, since none of this
+//! reaches the WebView). Deliberately *not* used for the free-form
+//! diagnostic log tail (`push_log`/`get_log_tail`): translating every
+//! interpolated log line is a much bigger, lower-value undertaking than the
+//! primary UI text this covers, and that log is debug scrollback the user
+//! opts into, not primary UI.
+//!
+//! Locale is detected fresh at each call site (cheap OS call, no caching
+//! needed) using the same "positively-detected English, else Chinese" rule
+//! `@deepseek-ai/dsh-client-locale` uses for the harness web UI itself (see
+//! GitHub issue #23's own analysis of that package). Deliberately independent
+//! of that package's persisted `locale.preference` setting: the harness page
+//! is a plain remote page with zero Tauri IPC access (see lib.rs's module doc
+//! comment), so there is no in-repo way to read its setting, and no reason to
+//! invent a side channel just for this.
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Lang {
+    Zh,
+    En,
+}
+
+pub fn detect() -> Lang {
+    match sys_locale::get_locale() {
+        Some(locale) if locale.to_lowercase().starts_with("en") => Lang::En,
+        _ => Lang::Zh,
+    }
+}
+
+/// `en` on a detected English locale, `zh` otherwise — see the module doc
+/// comment for why "otherwise" (not just "on detected Chinese") is correct.
+/// For strings that need a value interpolated somewhere other than a plain
+/// trailing position (surrounding punctuation/word order genuinely differs
+/// between the two languages), call sites branch on `Lang` directly instead
+/// of trying to force this helper's shape onto them.
+pub fn tr(lang: Lang, zh: &'static str, en: &'static str) -> &'static str {
+    match lang {
+        Lang::En => en,
+        Lang::Zh => zh,
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@
 //! is not enabled. All shell actions go through the native menu/tray and the
 //! local boot page.
 
+mod i18n;
 mod menu;
 mod panel;
 mod server;
@@ -224,7 +225,7 @@ fn open_in_browser(app: AppHandle, state: State<'_, AppState>) -> Result<(), Str
 #[tauri::command]
 fn open_external_url(app: AppHandle, url: String) -> Result<(), String> {
     if !url.starts_with("https://github.com/") {
-        return Err("仅支持打开 GitHub 仓库链接。".to_string());
+        return Err(i18n::tr(i18n::detect(), "仅支持打开 GitHub 仓库链接。", "Only GitHub repository links can be opened.").to_string());
     }
     app.opener().open_url(url, None::<&str>).map_err(|e| e.to_string())
 }
@@ -279,7 +280,7 @@ async fn install_update(app: AppHandle) -> Result<(), String> {
         .check()
         .await
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| "没有可用的更新".to_string())?;
+        .ok_or_else(|| i18n::tr(i18n::detect(), "没有可用的更新", "No update available").to_string())?;
     update
         .download_and_install(|_, _| {}, || {})
         .await
@@ -914,11 +915,16 @@ pub fn run() {
                 if state.hide_notice_shown.swap(true, Ordering::Relaxed) {
                     return;
                 }
+                let lang = i18n::detect();
                 let _ = app
                     .notification()
                     .builder()
-                    .title("DeepSeek Harness 已转入后台")
-                    .body("服务仍在运行；从系统托盘图标可重新打开窗口或退出。")
+                    .title(i18n::tr(lang, "DeepSeek Harness 已转入后台", "DeepSeek Harness is running in the background"))
+                    .body(i18n::tr(
+                        lang,
+                        "服务仍在运行；从系统托盘图标可重新打开窗口或退出。",
+                        "The service is still running. Use the tray icon to reopen the window or quit.",
+                    ))
                     .show();
             }
         })

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -13,6 +13,8 @@ use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent}
 use tauri::{AppHandle, Wry};
 use tauri_plugin_autostart::ManagerExt;
 
+use crate::i18n;
+
 pub const MENU_OPEN_BROWSER: &str = "open_browser";
 pub const MENU_RESTART: &str = "restart";
 pub const MENU_OPEN_DATA_DIR: &str = "open_data_dir";
@@ -23,6 +25,7 @@ pub const MENU_QUIT: &str = "quit";
 /// macOS-only — see the `set_menu()` callsite in lib.rs for why.
 #[cfg(target_os = "macos")]
 pub fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+    let lang = i18n::detect();
     // The first submenu becomes the macOS application menu (its name is
     // replaced by the app name). It must carry the standard roles — the
     // Quit role in particular is what binds ⌘Q (key equivalent "q" + the
@@ -43,20 +46,27 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             &PredefinedMenuItem::quit(app, None)?,
         ],
     )?;
-    let open_browser = MenuItem::with_id(app, MENU_OPEN_BROWSER, "在浏览器中打开", true, None::<&str>)?;
-    let restart = MenuItem::with_id(app, MENU_RESTART, "重启服务", true, None::<&str>)?;
-    let open_data_dir = MenuItem::with_id(app, MENU_OPEN_DATA_DIR, "打开数据目录 (~/.dsh)", true, None::<&str>)?;
+    let open_browser = MenuItem::with_id(app, MENU_OPEN_BROWSER, i18n::tr(lang, "在浏览器中打开", "Open in Browser"), true, None::<&str>)?;
+    let restart = MenuItem::with_id(app, MENU_RESTART, i18n::tr(lang, "重启服务", "Restart Service"), true, None::<&str>)?;
+    let open_data_dir = MenuItem::with_id(
+        app,
+        MENU_OPEN_DATA_DIR,
+        i18n::tr(lang, "打开数据目录 (~/.dsh)", "Open Data Folder (~/.dsh)"),
+        true,
+        None::<&str>,
+    )?;
     // The custom "退出" item is gone: the app menu's standard Quit role
     // covers quitting (with the ⌘Q shortcut), and tearing the server down
     // happens once in lib.rs's ExitRequested handler for every quit path.
-    let file = Submenu::with_items(app, "文件", true, &[&open_browser, &restart, &open_data_dir])?;
+    let file = Submenu::with_items(app, i18n::tr(lang, "文件", "File"), true, &[&open_browser, &restart, &open_data_dir])?;
     // macOS 上 Cmd+C / Cmd+V / Cmd+X / Cmd+A 等快捷键必须由菜单中的标准
     // "编辑"项提供（通过 responder chain 分发到 WebView），缺少它们会导致
     // 剪切/复制/粘贴失效。PredefinedMenuItem 的角色项会自动带上正确的
-    // 快捷键与选择器，无需手动注册处理逻辑。
+    // 快捷键与选择器，无需手动注册处理逻辑。它们自身的文本由 AppKit 按系统
+    // 语言自动本地化，这里不需要（也不能）手动翻译。
     let edit = Submenu::with_items(
         app,
-        "编辑",
+        i18n::tr(lang, "编辑", "Edit"),
         true,
         &[
             &PredefinedMenuItem::undo(app, None)?,
@@ -73,7 +83,7 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     // those shortcuts are dead for the same reason ⌘Q was.
     let window = Submenu::with_items(
         app,
-        "窗口",
+        i18n::tr(lang, "窗口", "Window"),
         true,
         &[
             &PredefinedMenuItem::minimize(app, None)?,
@@ -94,23 +104,30 @@ pub fn build_tray(
     app: &AppHandle,
     on_action: impl Fn(&AppHandle, &str) + Send + Sync + 'static,
 ) -> tauri::Result<CheckMenuItem<Wry>> {
-    let show = MenuItem::with_id(app, MENU_SHOW_WINDOW, "显示窗口", true, None::<&str>)?;
-    let open_browser = MenuItem::with_id(app, MENU_OPEN_BROWSER, "在浏览器中打开", true, None::<&str>)?;
-    let restart = MenuItem::with_id(app, MENU_RESTART, "重启服务", true, None::<&str>)?;
+    let lang = i18n::detect();
+    let show = MenuItem::with_id(app, MENU_SHOW_WINDOW, i18n::tr(lang, "显示窗口", "Show Window"), true, None::<&str>)?;
+    let open_browser = MenuItem::with_id(app, MENU_OPEN_BROWSER, i18n::tr(lang, "在浏览器中打开", "Open in Browser"), true, None::<&str>)?;
+    let restart = MenuItem::with_id(app, MENU_RESTART, i18n::tr(lang, "重启服务", "Restart Service"), true, None::<&str>)?;
     // On Windows/Linux this tray is the *only* menu (see the `set_menu()`
     // callsite in lib.rs) — include everything the removed window menu
     // offered, not just what macOS's menu bar leaves uncovered.
-    let open_data_dir = MenuItem::with_id(app, MENU_OPEN_DATA_DIR, "打开数据目录 (~/.dsh)", true, None::<&str>)?;
+    let open_data_dir = MenuItem::with_id(
+        app,
+        MENU_OPEN_DATA_DIR,
+        i18n::tr(lang, "打开数据目录 (~/.dsh)", "Open Data Folder (~/.dsh)"),
+        true,
+        None::<&str>,
+    )?;
     let autostart_enabled = app.autolaunch().is_enabled().unwrap_or(false);
     let autostart = CheckMenuItem::with_id(
         app,
         MENU_TOGGLE_AUTOSTART,
-        "开机自动启动",
+        i18n::tr(lang, "开机自动启动", "Launch at Startup"),
         true,
         autostart_enabled,
         None::<&str>,
     )?;
-    let quit = MenuItem::with_id(app, MENU_QUIT, "退出", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, MENU_QUIT, i18n::tr(lang, "退出", "Quit"), true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&show, &open_browser, &restart, &open_data_dir, &autostart, &quit])?;
 
     // Shared between on_menu_event and on_tray_icon_event below (a left

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -401,15 +401,20 @@ pub fn editable_preview(root: &Path, rel_path: &str) -> EditablePreview {
 /// `save_file`'s round-trip verification and any other consumer that just
 /// wants "what does this file currently contain" reaches for.
 pub fn text_preview(root: &Path, rel_path: &str) -> FileContent {
+    let lang = crate::i18n::detect();
     let full_path = root.join(rel_path);
     let Ok(metadata) = fs::metadata(&full_path) else {
-        return FileContent::Error { message: "文件不存在".to_string() };
+        return FileContent::Error {
+            message: crate::i18n::tr(lang, "文件不存在", "File does not exist").to_string(),
+        };
     };
     if metadata.len() > MAX_PREVIEW_BYTES {
         return FileContent::TooLarge { bytes: metadata.len() };
     }
     let Ok(bytes) = fs::read(&full_path) else {
-        return FileContent::Error { message: "无法读取文件".to_string() };
+        return FileContent::Error {
+            message: crate::i18n::tr(lang, "无法读取文件", "Unable to read file").to_string(),
+        };
     };
     // A NUL byte anywhere is a cheap, reliable-enough binary heuristic —
     // the same one git itself uses to decide whether a file diffs as text.
@@ -457,11 +462,24 @@ fn git_show_head(root: &Path, rel_path: &str) -> Option<FileContent> {
 /// where the same class of bug would only misdirect a preview rather than
 /// overwrite a file outside the workspace.
 fn resolve_within_root(root: &Path, rel_path: &str) -> Result<PathBuf, String> {
+    let lang = crate::i18n::detect();
     let candidate = root.join(rel_path);
-    let root_canon = root.canonicalize().map_err(|e| format!("无法解析工作区路径: {e}"))?;
-    let candidate_canon = candidate.canonicalize().map_err(|e| format!("无法解析文件路径: {e}"))?;
+    let root_canon = root.canonicalize().map_err(|e| {
+        if lang == crate::i18n::Lang::En {
+            format!("Failed to resolve workspace path: {e}")
+        } else {
+            format!("无法解析工作区路径: {e}")
+        }
+    })?;
+    let candidate_canon = candidate.canonicalize().map_err(|e| {
+        if lang == crate::i18n::Lang::En {
+            format!("Failed to resolve file path: {e}")
+        } else {
+            format!("无法解析文件路径: {e}")
+        }
+    })?;
     if !candidate_canon.starts_with(&root_canon) {
-        return Err("路径超出工作区范围".to_string());
+        return Err(crate::i18n::tr(lang, "路径超出工作区范围", "Path is outside the workspace").to_string());
     }
     Ok(candidate_canon)
 }
@@ -471,8 +489,15 @@ fn resolve_within_root(root: &Path, rel_path: &str) -> Result<PathBuf, String> {
 /// exist) — this is an edit-and-save path for a file the tree already
 /// listed, not a general file-creation API.
 pub fn save_file(root: &Path, rel_path: &str, content: &str) -> Result<(), String> {
+    let lang = crate::i18n::detect();
     let full_path = resolve_within_root(root, rel_path)?;
-    fs::write(&full_path, content).map_err(|e| format!("保存失败: {e}"))
+    fs::write(&full_path, content).map_err(|e| {
+        if lang == crate::i18n::Lang::En {
+            format!("Save failed: {e}")
+        } else {
+            format!("保存失败: {e}")
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -30,6 +30,8 @@ use std::os::windows::process::CommandExt as _;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
+use crate::i18n::{self, Lang};
+
 /// Tray icon id, shared with `menu::build_tray`'s `TrayIconBuilder::with_id`
 /// so `set_status` can look the tray up by id to update its tooltip.
 pub const TRAY_ID: &str = "main-tray";
@@ -139,12 +141,13 @@ pub type Shared = Arc<Mutex<DshServer>>;
 /// opening the window. Kept short (tray tooltips are single-line on most
 /// platforms) rather than reusing the boot page's more detailed messages.
 fn tray_tooltip_text(status: &ServerStatus) -> String {
+    let lang = i18n::detect();
     let detail = match status {
-        ServerStatus::Idle => "空闲",
-        ServerStatus::Starting { .. } => "启动中…",
-        ServerStatus::Running { .. } => "运行中",
-        ServerStatus::Stopped { .. } => "已停止",
-        ServerStatus::Error { .. } => "⚠ 出错",
+        ServerStatus::Idle => i18n::tr(lang, "空闲", "Idle"),
+        ServerStatus::Starting { .. } => i18n::tr(lang, "启动中…", "Starting…"),
+        ServerStatus::Running { .. } => i18n::tr(lang, "运行中", "Running"),
+        ServerStatus::Stopped { .. } => i18n::tr(lang, "已停止", "Stopped"),
+        ServerStatus::Error { .. } => i18n::tr(lang, "⚠ 出错", "⚠ Error"),
     };
     format!("DeepSeek Harness — {detail}")
 }
@@ -348,11 +351,16 @@ pub(crate) fn kill_process_tree(pid: u32) {
 // ── resolution ───────────────────────────────────────────────────────────────
 
 fn resolve_node(app: &AppHandle) -> Result<String, String> {
+    let lang = i18n::detect();
     if let Some(node) = env_nonempty("DSH_DESKTOP_NODE") {
         if Path::new(&node).exists() {
             return Ok(plain_win_path(Path::new(&node)));
         }
-        return Err(format!("DSH_DESKTOP_NODE 指向的文件不存在: {node}"));
+        return Err(if lang == Lang::En {
+            format!("DSH_DESKTOP_NODE points to a file that doesn't exist: {node}")
+        } else {
+            format!("DSH_DESKTOP_NODE 指向的文件不存在: {node}")
+        });
     }
     // bundled runtime shipped with packaged builds
     if let Ok(res) = app.path().resource_dir() {
@@ -367,22 +375,31 @@ fn resolve_node(app: &AppHandle) -> Result<String, String> {
     hide_console(&mut probe);
     match probe.output() {
         Ok(out) if out.status.success() => Ok("node".to_string()),
-        _ => Err(
+        _ => Err(if lang == Lang::En {
+            "Node.js not detected. Install Node.js (https://nodejs.org), or set the \
+             DSH_DESKTOP_NODE environment variable to the path of node.exe."
+                .to_string()
+        } else {
             "未检测到 Node.js：请安装 Node.js（https://nodejs.org），\
              或在环境变量 DSH_DESKTOP_NODE 中指定 node.exe 的路径。"
-                .to_string(),
-        ),
+                .to_string()
+        }),
     }
 }
 
 fn resolve_bin(app: &AppHandle, server: &Shared) -> Result<String, String> {
+    let lang = i18n::detect();
     if let Some(bin) = env_nonempty("DSH_DESKTOP_DSH_BIN") {
         let p = PathBuf::from(&bin);
         if p.exists() {
             push_log(server, format!("使用 DSH_DESKTOP_DSH_BIN: {bin}"));
             return Ok(plain_win_path(&p));
         }
-        return Err(format!("DSH_DESKTOP_DSH_BIN 指向的文件不存在: {bin}"));
+        return Err(if lang == Lang::En {
+            format!("DSH_DESKTOP_DSH_BIN points to a file that doesn't exist: {bin}")
+        } else {
+            format!("DSH_DESKTOP_DSH_BIN 指向的文件不存在: {bin}")
+        });
     }
     // bundled runtime shipped with packaged builds
     if let Ok(res) = app.path().resource_dir() {
@@ -397,21 +414,36 @@ fn resolve_bin(app: &AppHandle, server: &Shared) -> Result<String, String> {
         install_runtime(app, server, &rd)?;
     }
     if !bin.exists() {
-        return Err(format!("dsh 运行时安装失败（{}），请查看日志。", rd.display()));
+        return Err(if lang == Lang::En {
+            format!("dsh runtime installation failed ({}). Check the logs.", rd.display())
+        } else {
+            format!("dsh 运行时安装失败（{}），请查看日志。", rd.display())
+        });
     }
     Ok(plain_win_path(&bin))
 }
 
 fn install_runtime(app: &AppHandle, server: &Shared, rd: &Path) -> Result<(), String> {
+    let lang = i18n::detect();
     let version = env_nonempty("DSH_DESKTOP_DSH_VERSION").unwrap_or_else(|| DSH_VERSION_DEFAULT.to_string());
     let target = format!("@deepseek-ai/dsh@{version}");
-    fs::create_dir_all(rd).map_err(|e| format!("无法创建运行时目录 {}: {e}", rd.display()))?;
+    fs::create_dir_all(rd).map_err(|e| {
+        if lang == Lang::En {
+            format!("Failed to create runtime directory {}: {e}", rd.display())
+        } else {
+            format!("无法创建运行时目录 {}: {e}", rd.display())
+        }
+    })?;
     push_log(server, format!("首次使用：安装 dsh 运行时 ({target}) → {}", rd.display()));
     set_status(
         app,
         server,
         ServerStatus::Starting {
-            detail: format!("安装 dsh 运行时 ({version})…"),
+            detail: if lang == Lang::En {
+                format!("Installing dsh runtime ({version})…")
+            } else {
+                format!("安装 dsh 运行时 ({version})…")
+            },
         },
     );
     let prefix = plain_win_path(rd);
@@ -429,11 +461,13 @@ fn install_runtime(app: &AppHandle, server: &Shared, rd: &Path) -> Result<(), St
         "--fetch-retry-mintimeout=2000",
     ]);
     own_process_group(&mut cmd);
-    let mut output = cmd
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("无法运行 npm install: {e}"))?;
+    let mut output = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn().map_err(|e| {
+        if lang == Lang::En {
+            format!("Failed to run npm install: {e}")
+        } else {
+            format!("无法运行 npm install: {e}")
+        }
+    })?;
 
     // Stream npm output into the log ring buffer so first-run installs
     // (hundreds of MB) are visible instead of silent.
@@ -468,7 +502,11 @@ fn install_runtime(app: &AppHandle, server: &Shared, rd: &Path) -> Result<(), St
                 // taskkill whatever unrelated process the OS has since
                 // reused that PID number for.
                 server.lock().unwrap().install_pid = None;
-                return Err(format!("npm install 进程错误: {e}"));
+                return Err(if lang == Lang::En {
+                    format!("npm install process error: {e}")
+                } else {
+                    format!("npm install 进程错误: {e}")
+                });
             }
         }
     };
@@ -477,7 +515,11 @@ fn install_runtime(app: &AppHandle, server: &Shared, rd: &Path) -> Result<(), St
         s.install_pid = None;
     }
     if !status.success() {
-        return Err(format!("npm install 失败（exit {:?}），请查看日志。", status.code()));
+        return Err(if lang == Lang::En {
+            format!("npm install failed (exit {:?}). Check the logs.", status.code())
+        } else {
+            format!("npm install 失败（exit {:?}），请查看日志。", status.code())
+        });
     }
     Ok(())
 }
@@ -516,10 +558,16 @@ pub enum PluginInstallEvent {
 /// disabled state is a UX nicety on top of this, not a substitute for it —
 /// this guard is what actually makes it safe.
 pub fn install_plugin(app: &AppHandle, server: &Shared, package: &str) -> Result<(), String> {
+    let lang = i18n::detect();
     {
         let mut s = server.lock().unwrap();
         if s.plugin_install_pid.is_some() {
-            return Err("已有插件正在安装，请等待完成后再试。".to_string());
+            return Err(i18n::tr(
+                lang,
+                "已有插件正在安装，请等待完成后再试。",
+                "A plugin install is already in progress — wait for it to finish first.",
+            )
+            .to_string());
         }
         // Reserved with a placeholder before resolve_node/resolve_bin (which
         // can themselves install the runtime and take a while) so a second
@@ -556,7 +604,11 @@ pub fn install_plugin(app: &AppHandle, server: &Shared, package: &str) -> Result
         Ok(c) => c,
         Err(e) => {
             server.lock().unwrap().plugin_install_pid = None;
-            return Err(format!("无法运行 dsh plugin add: {e}"));
+            return Err(if lang == Lang::En {
+                format!("Failed to run dsh plugin add: {e}")
+            } else {
+                format!("无法运行 dsh plugin add: {e}")
+            });
         }
     };
 
@@ -638,10 +690,16 @@ pub enum PnpmInstallEvent {
 /// bare form spawned fine on other platforms but failed outright here with
 /// a raw "program not found" the confirm view had no way to explain.
 pub fn install_pnpm(app: &AppHandle, server: &Shared) -> Result<(), String> {
+    let lang = i18n::detect();
     {
         let mut s = server.lock().unwrap();
         if s.pnpm_install_pid.is_some() {
-            return Err("pnpm 正在安装，请等待完成后再试。".to_string());
+            return Err(i18n::tr(
+                lang,
+                "pnpm 正在安装，请等待完成后再试。",
+                "pnpm is already being installed — wait for it to finish first.",
+            )
+            .to_string());
         }
         s.pnpm_install_pid = Some(0);
     }
@@ -655,9 +713,11 @@ pub fn install_pnpm(app: &AppHandle, server: &Shared) -> Result<(), String> {
         Ok(c) => c,
         Err(e) => {
             server.lock().unwrap().pnpm_install_pid = None;
-            return Err(format!(
-                "无法运行 npm install -g pnpm: {e}（请确认系统已安装 Node.js/npm）"
-            ));
+            return Err(if lang == Lang::En {
+                format!("Failed to run npm install -g pnpm: {e} (make sure Node.js/npm is installed)")
+            } else {
+                format!("无法运行 npm install -g pnpm: {e}（请确认系统已安装 Node.js/npm）")
+            });
         }
     };
 
@@ -961,9 +1021,16 @@ pub(crate) fn workspace_dir(app: &AppHandle) -> PathBuf {
 
 /// Spawn the server process and start its reader/exit-watcher threads.
 fn spawn(app: &AppHandle, server: &Shared, node: &str, bin: &str, port: u16) -> Result<(), String> {
+    let lang = i18n::detect();
     let cwd = workspace_dir(app);
     let cwd_plain = plain_win_path(&cwd);
-    fs::create_dir_all(&cwd).map_err(|e| format!("无法创建工作目录 {}: {e}", cwd.display()))?;
+    fs::create_dir_all(&cwd).map_err(|e| {
+        if lang == Lang::En {
+            format!("Failed to create working directory {}: {e}", cwd.display())
+        } else {
+            format!("无法创建工作目录 {}: {e}", cwd.display())
+        }
+    })?;
 
     push_log(
         server,
@@ -980,7 +1047,13 @@ fn spawn(app: &AppHandle, server: &Shared, node: &str, bin: &str, port: u16) -> 
     cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
     own_process_group(&mut cmd);
     hide_console(&mut cmd);
-    let mut child = cmd.spawn().map_err(|e| format!("启动 dsh 失败: {e}"))?;
+    let mut child = cmd.spawn().map_err(|e| {
+        if lang == Lang::En {
+            format!("Failed to start dsh: {e}")
+        } else {
+            format!("启动 dsh 失败: {e}")
+        }
+    })?;
 
     let pid = child.id();
     println!("[dsh-desktop] spawned dsh pid {pid} on port {port}");
@@ -995,7 +1068,11 @@ fn spawn(app: &AppHandle, server: &Shared, node: &str, bin: &str, port: u16) -> 
         app,
         server,
         ServerStatus::Starting {
-            detail: format!("服务启动中 (端口 {port})…"),
+            detail: if lang == Lang::En {
+                format!("Service starting (port {port})…")
+            } else {
+                format!("服务启动中 (端口 {port})…")
+            },
         },
     );
 
@@ -1083,14 +1160,22 @@ fn spawn(app: &AppHandle, server: &Shared, node: &str, bin: &str, port: u16) -> 
                 &app3,
                 &srv4,
                 ServerStatus::Error {
-                    message: format!("dsh 服务异常退出 (exit {code:?})，1 秒后自动重启…"),
+                    message: if lang == Lang::En {
+                        format!("dsh service exited unexpectedly (exit {code:?}) — restarting automatically in 1s…")
+                    } else {
+                        format!("dsh 服务异常退出 (exit {code:?})，1 秒后自动重启…")
+                    },
                 },
             );
             thread::sleep(Duration::from_secs(1));
             let _ = start(&app3, &srv4);
         } else {
             let status = ServerStatus::Error {
-                message: format!("dsh 服务异常退出 (exit {code:?})，自动重启已停止，请手动重试。"),
+                message: if lang == Lang::En {
+                    format!("dsh service exited unexpectedly (exit {code:?}). Automatic restart has stopped — retry manually.")
+                } else {
+                    format!("dsh 服务异常退出 (exit {code:?})，自动重启已停止，请手动重试。")
+                },
             };
             {
                 let mut s = srv4.lock().unwrap();
@@ -1162,6 +1247,7 @@ pub fn start(app: &AppHandle, server: &Shared) -> Result<(), String> {
 }
 
 fn start_inner(app: &AppHandle, server: &Shared) -> Result<(), String> {
+    let lang = i18n::detect();
     // Attach to an already-running harness on the default port instead of
     // spawning a second instance (two servers would race on ~/.dsh). This
     // happens before resolving node/runtime so attach mode needs nothing.
@@ -1222,7 +1308,7 @@ fn start_inner(app: &AppHandle, server: &Shared) -> Result<(), String> {
                 app,
                 server,
                 ServerStatus::Starting {
-                    detail: "确认 3080 端口占用情况…".to_string(),
+                    detail: i18n::tr(lang, "确认 3080 端口占用情况…", "Checking what's using port 3080…").to_string(),
                 },
             );
             if probe_dsh_with_retries(&default_url, 3, 400) {
@@ -1259,7 +1345,12 @@ fn start_inner(app: &AppHandle, server: &Shared) -> Result<(), String> {
                 app,
                 server,
                 ServerStatus::Error {
-                    message: "启动超时：dsh 进程仍在运行，但未能确认服务已就绪，请查看日志。".to_string(),
+                    message: i18n::tr(
+                        lang,
+                        "启动超时：dsh 进程仍在运行，但未能确认服务已就绪，请查看日志。",
+                        "Startup timed out: the dsh process is still running, but readiness couldn't be confirmed. Check the logs.",
+                    )
+                    .to_string(),
                 },
             );
             return Ok(());
@@ -1277,7 +1368,7 @@ pub fn info(app: &AppHandle, server: &Shared) -> serde_json::Value {
     let dsh_version = env_nonempty("DSH_DESKTOP_DSH_VERSION").unwrap_or_else(|| DSH_VERSION_DEFAULT.to_string());
     serde_json::json!({
         "dshVersion": dsh_version,
-        "nodePath": node.unwrap_or_else(|| "未检测到".to_string()),
+        "nodePath": node.unwrap_or_else(|| i18n::tr(i18n::detect(), "未检测到", "Not detected").to_string()),
         "binPath": bin.unwrap_or_default(),
         "dshHome": dsh_home_dir(app).to_string_lossy(),
         "runtimeDir": runtime_dir(app).to_string_lossy(),

--- a/ui/app.js
+++ b/ui/app.js
@@ -86,6 +86,245 @@ const els = {
   btnPreviewRevert: document.getElementById("btn-preview-revert"),
 };
 
+// ── i18n ─────────────────────────────────────────────────────────────────
+//
+// This shell (index.html + this file) is its own bilingual surface,
+// deliberately independent of the harness iframe's own locale.preference
+// setting: that page is a plain remote page with zero Tauri IPC access (see
+// lib.rs's module doc comment), so there's no channel to read its setting
+// through, and no reason to invent one. Detected straight from
+// navigator.language instead — WebView2/WKWebView both set this from the OS
+// UI language — using the same "positively-detected English, else Chinese"
+// fallback @deepseek-ai/dsh-client-locale itself uses (see GitHub issue
+// #23's own analysis of that package). menu.rs/lib.rs/server.rs/panel.rs
+// mirror this exact rule on the native (Rust) side of the shell, via
+// sys_locale — the two halves detect independently but land on the same
+// answer since both read the same OS setting.
+const LANG = (navigator.language || "zh").toLowerCase().startsWith("en") ? "en" : "zh";
+document.documentElement.lang = LANG === "en" ? "en" : "zh-CN";
+
+const STRINGS = {
+  zh: {
+    menu: "菜单",
+    openInBrowser: "在浏览器中打开",
+    restartService: "重启服务",
+    appMenuOpenDataDir: "打开数据目录",
+    autostartToggle: "开机自动启动",
+    quit: "退出",
+    pluginMarket: "插件市场",
+    tagline: "探索未至之境",
+    terminal: "终端",
+    diffComingSoon: "Diff（即将推出）",
+    files: "文件",
+    minimize: "最小化",
+    maximize: "最大化",
+    restore: "还原",
+    close: "关闭",
+    updateNow: "立即更新",
+    dismiss: "忽略",
+    startingTitle: "正在启动 DeepSeek Harness…",
+    preparingLocalService: "准备本地服务",
+    viewLogs: "查看日志",
+    hideLogs: "隐藏日志",
+    providerTip:
+      "首次使用提示：默认使用 DeepSeek 官方模型。如需接入 OpenAI / Anthropic / Gemini " +
+      "等其他模型，进入后可在「设置 → 模型 → 添加提供方」中配置，随时可改。",
+    gotIt: "知道了",
+    startupFailed: "启动失败",
+    retry: "重试",
+    refreshTreeTitle: "刷新文件树与 Git 状态",
+    collapse: "收起",
+    chooseWorkspaceTitle: "选择要在文件树中查看的工作区",
+    unsavedChangesTitle: "有未保存的改动",
+    revert: "还原",
+    revertTitle: "放弃改动，还原为已保存内容",
+    save: "保存",
+    saveTitle: "保存改动 (Ctrl+S)",
+    closePreviewTitle: "关闭预览",
+    restartTerminalTitle: "重启终端",
+    closeTerminalTitle: "关闭终端",
+    pluginSearchPlaceholder: "搜索插件名称或描述…",
+    sortByStarsTitle: "按 star 数排序",
+    sortByStarsAsc: "按 star 数从低到高排序",
+    sortByStarsDesc: "按 star 数从高到低排序",
+    backToList: "返回列表",
+    pluginRiskTitle: "安装第三方插件存在风险。",
+    pluginRiskBody:
+      "插件会以当前用户权限运行第三方代码，可读取本机文件、使用你的登录凭据、访问网络，安装/审批环节不会对其进行沙箱隔离。来源仓库的构建脚本也会在安装时执行。仅安装你信任的来源。",
+    commandToRun: "将执行的命令",
+    pnpmNotFoundTitle: "未检测到 pnpm。",
+    pnpmNotFoundBody: "插件安装依赖 pnpm，请先安装后再继续。",
+    installPnpmOneClick: "一键安装 pnpm",
+    installing: "安装中…",
+    viewSource: "查看来源",
+    viewSourceTitle: "在浏览器中查看来源仓库",
+    confirmInstall: "确认安装",
+    checkingEnvironment: "正在检测环境…",
+    installLog: "安装日志",
+
+    unknownError: "未知错误",
+    serviceStopped: (code) => `服务已停止（exit ${code}）。`,
+    statusFetchFailed: (err) => `无法获取状态: ${err}`,
+    logReadFailed: (err) => `无法读取日志: ${err}`,
+    allCategories: "全部分类",
+    invalidResponseFormat: "响应格式不正确",
+    pluginCountStatus: (shown, total, capped) =>
+      `${shown} / ${total} 个插件${capped ? `（仅显示前 ${PLUGIN_GRID_RENDER_CAP} 个，请搜索缩小范围）` : ""}`,
+    noPluginsMatched: "没有匹配的插件。",
+    install: "安装",
+    loadingCatalog: "正在加载插件目录…",
+    catalogLoadFailed: (err) => `插件目录加载失败: ${err}`,
+    installStartFailed: (err) => `启动安装失败: ${err}`,
+    sourceMeta: (url, stars) => `来源：${url} · ★ ${stars}`,
+    processExited: "[进程已结束]",
+    terminalStartFailed: (err) => `终端启动失败: ${err}`,
+    installComplete: "安装完成。",
+    installFailedExit: (code) => `安装失败（exit ${code}）。`,
+    pnpmInstallComplete: "pnpm 安装完成。",
+    pnpmInstallFailedExit: (code) => `pnpm 安装失败（exit ${code}）。`,
+    startFailed: (err) => `启动失败: ${err}`,
+    restartFailed: (err) => `重启失败: ${err}`,
+    updating: "正在更新…",
+    updateFailed: (err) => `更新失败: ${err}`,
+    newVersionFound: (version) => `发现新版本 ${version}`,
+    confirmDiscardChanges: "有未保存的改动，确定要放弃吗？",
+    cannotReadHistoricalContent: "无法读取此文件的历史内容",
+    binaryFileNoPreview: "二进制文件，无法预览",
+    fileTooLarge: (mb) => `文件过大（${mb} MB），未加载预览`,
+    loading: "加载中…",
+    previewLoadFailed: (err) => `预览加载失败: ${err}`,
+    confirmRevert: "放弃当前改动，还原为上次保存的内容？",
+    saveFailed: (err) => `保存失败: ${err}`,
+    autoFollowWithLabel: (label) => `自动跟随（${label}）`,
+    autoFollowSession: "自动跟随当前会话",
+    emptyWorkspace: "空工作区",
+    treeLoadFailed: (err) => `无法加载文件树: ${err}`,
+    fileNotInKnownWorkspace: "该文件不属于任何已知工作区",
+    dataDirLabel: (path) => `数据目录 ${path}`,
+  },
+  en: {
+    menu: "Menu",
+    openInBrowser: "Open in Browser",
+    restartService: "Restart Service",
+    appMenuOpenDataDir: "Open Data Folder",
+    autostartToggle: "Launch at Startup",
+    quit: "Quit",
+    pluginMarket: "Plugin Market",
+    tagline: "Explore the uncharted.",
+    terminal: "Terminal",
+    diffComingSoon: "Diff (Coming Soon)",
+    files: "Files",
+    minimize: "Minimize",
+    maximize: "Maximize",
+    restore: "Restore",
+    close: "Close",
+    updateNow: "Update Now",
+    dismiss: "Dismiss",
+    startingTitle: "Starting DeepSeek Harness…",
+    preparingLocalService: "Preparing local service",
+    viewLogs: "View Logs",
+    hideLogs: "Hide Logs",
+    providerTip:
+      "First time here: DeepSeek's official models are used by default. To add OpenAI / Anthropic / " +
+      "Gemini or other providers, go to Settings → Models → Add Provider after launch — you can change this anytime.",
+    gotIt: "Got It",
+    startupFailed: "Startup Failed",
+    retry: "Retry",
+    refreshTreeTitle: "Refresh file tree and Git status",
+    collapse: "Collapse",
+    chooseWorkspaceTitle: "Choose which workspace to show in the file tree",
+    unsavedChangesTitle: "Unsaved changes",
+    revert: "Revert",
+    revertTitle: "Discard changes and revert to the last saved version",
+    save: "Save",
+    saveTitle: "Save changes (Ctrl+S)",
+    closePreviewTitle: "Close Preview",
+    restartTerminalTitle: "Restart Terminal",
+    closeTerminalTitle: "Close Terminal",
+    pluginSearchPlaceholder: "Search plugin name or description…",
+    sortByStarsTitle: "Sort by star count",
+    sortByStarsAsc: "Sort by star count, low to high",
+    sortByStarsDesc: "Sort by star count, high to low",
+    backToList: "Back to List",
+    pluginRiskTitle: "Installing third-party plugins carries risk.",
+    pluginRiskBody:
+      "Plugins run third-party code with your current user permissions — they can read local files, use your login " +
+      "credentials, and access the network. Installation isn't sandboxed, and the source repo's build scripts run " +
+      "during install too. Only install sources you trust.",
+    commandToRun: "Command to run",
+    pnpmNotFoundTitle: "pnpm not found.",
+    pnpmNotFoundBody: "Plugin installation requires pnpm — install it first to continue.",
+    installPnpmOneClick: "Install pnpm",
+    installing: "Installing…",
+    viewSource: "View Source",
+    viewSourceTitle: "View the source repository in your browser",
+    confirmInstall: "Confirm Install",
+    checkingEnvironment: "Checking environment…",
+    installLog: "Install Log",
+
+    unknownError: "Unknown error",
+    serviceStopped: (code) => `Service stopped (exit ${code}).`,
+    statusFetchFailed: (err) => `Failed to fetch status: ${err}`,
+    logReadFailed: (err) => `Failed to read log: ${err}`,
+    allCategories: "All Categories",
+    invalidResponseFormat: "Invalid response format",
+    pluginCountStatus: (shown, total, capped) =>
+      `${shown} / ${total} plugins${capped ? ` (showing first ${PLUGIN_GRID_RENDER_CAP} — search to narrow down)` : ""}`,
+    noPluginsMatched: "No matching plugins.",
+    install: "Install",
+    loadingCatalog: "Loading plugin catalog…",
+    catalogLoadFailed: (err) => `Failed to load plugin catalog: ${err}`,
+    installStartFailed: (err) => `Failed to start install: ${err}`,
+    sourceMeta: (url, stars) => `Source: ${url} · ★ ${stars}`,
+    processExited: "[process exited]",
+    terminalStartFailed: (err) => `Failed to start terminal: ${err}`,
+    installComplete: "Install complete.",
+    installFailedExit: (code) => `Install failed (exit ${code}).`,
+    pnpmInstallComplete: "pnpm installed.",
+    pnpmInstallFailedExit: (code) => `pnpm install failed (exit ${code}).`,
+    startFailed: (err) => `Failed to start: ${err}`,
+    restartFailed: (err) => `Failed to restart: ${err}`,
+    updating: "Updating…",
+    updateFailed: (err) => `Update failed: ${err}`,
+    newVersionFound: (version) => `New version ${version} available`,
+    confirmDiscardChanges: "You have unsaved changes. Discard them?",
+    cannotReadHistoricalContent: "Unable to read this file's historical content",
+    binaryFileNoPreview: "Binary file, no preview available",
+    fileTooLarge: (mb) => `File too large (${mb} MB) — preview not loaded`,
+    loading: "Loading…",
+    previewLoadFailed: (err) => `Failed to load preview: ${err}`,
+    confirmRevert: "Discard current changes and revert to the last saved version?",
+    saveFailed: (err) => `Save failed: ${err}`,
+    autoFollowWithLabel: (label) => `Auto-follow (${label})`,
+    autoFollowSession: "Auto-follow current session",
+    emptyWorkspace: "Empty workspace",
+    treeLoadFailed: (err) => `Failed to load file tree: ${err}`,
+    fileNotInKnownWorkspace: "This file doesn't belong to any known workspace",
+    dataDirLabel: (path) => `Data folder ${path}`,
+  },
+};
+
+function t(key, ...args) {
+  const entry = STRINGS[LANG][key];
+  return typeof entry === "function" ? entry(...args) : entry;
+}
+
+// Applies every data-i18n[-title|-placeholder] attribute in index.html — the
+// static markup ships with Chinese text as its own fallback (never blank),
+// so this only needs to run once, after the DOM exists, to swap in whichever
+// language LANG resolved to.
+function applyStaticTranslations() {
+  for (const el of document.querySelectorAll("[data-i18n]")) {
+    el.textContent = t(el.getAttribute("data-i18n"));
+  }
+  for (const el of document.querySelectorAll("[data-i18n-title]")) {
+    el.title = t(el.getAttribute("data-i18n-title"));
+  }
+  for (const el of document.querySelectorAll("[data-i18n-placeholder]")) {
+    el.placeholder = t(el.getAttribute("data-i18n-placeholder"));
+  }
+}
+
 // Shown once (best-effort) during the first-ever boot wait, so new users
 // discover the existing Settings → 模型 → 添加提供方 flow without us having
 // to touch the harness page itself (it's iframed content with zero IPC
@@ -116,21 +355,21 @@ async function loadLogsInto(box) {
     const lines = await invoke("get_log_tail", { n: 200 });
     box.textContent = lines.join("\n");
   } catch (err) {
-    box.textContent = `无法读取日志: ${err}`;
+    box.textContent = t("logReadFailed", err);
   }
 }
 
 function toggleLogs() {
   logsVisible = !logsVisible;
   els.logBox.classList.toggle("hidden", !logsVisible);
-  els.btnLogs.textContent = logsVisible ? "隐藏日志" : "查看日志";
+  els.btnLogs.textContent = logsVisible ? t("hideLogs") : t("viewLogs");
   if (logsVisible) loadLogsInto(els.logBox);
 }
 
 function toggleLogsStarting() {
   logsStartingVisible = !logsStartingVisible;
   els.logBoxStarting.classList.toggle("hidden", !logsStartingVisible);
-  els.btnLogsStarting.textContent = logsStartingVisible ? "隐藏日志" : "查看日志";
+  els.btnLogsStarting.textContent = logsStartingVisible ? t("hideLogs") : t("viewLogs");
   if (logsStartingVisible) loadLogsInto(els.logBoxStarting);
 }
 
@@ -144,19 +383,17 @@ function render(status) {
     case "starting":
     case "idle":
       show("starting");
-      els.startingDetail.textContent = status.detail || "准备本地服务";
+      els.startingDetail.textContent = status.detail || t("preparingLocalService");
       break;
     case "stopped":
       show("error");
       els.harnessFrame.src = "about:blank";
-      els.errorMessage.textContent =
-        `服务已停止（exit ${status.code ?? "?"}）。` +
-        (status.message ? `\n${status.message}` : "");
+      els.errorMessage.textContent = t("serviceStopped", status.code ?? "?") + (status.message ? `\n${status.message}` : "");
       break;
     case "error":
       show("error");
       els.harnessFrame.src = "about:blank";
-      els.errorMessage.textContent = status.message || "未知错误";
+      els.errorMessage.textContent = status.message || t("unknownError");
       break;
     default:
       show("starting");
@@ -169,7 +406,7 @@ async function refresh() {
     render(status);
   } catch (err) {
     show("error");
-    els.errorMessage.textContent = `无法获取状态: ${err}`;
+    els.errorMessage.textContent = t("statusFetchFailed", err);
   }
 }
 
@@ -289,7 +526,7 @@ const ICON_RESTORE =
 async function syncMaximizeIcon() {
   const maximized = await appWindow.isMaximized();
   els.btnWinMaximize.innerHTML = maximized ? ICON_RESTORE : ICON_MAXIMIZE;
-  els.btnWinMaximize.title = maximized ? "还原" : "最大化";
+  els.btnWinMaximize.title = maximized ? t("restore") : t("maximize");
 }
 
 function initWindowControls() {
@@ -548,7 +785,7 @@ async function ensureTerminal() {
     await invoke("terminal_spawn", { cols: xterm.cols || 80, rows: xterm.rows || 24 });
     terminalSpawned = true;
   } catch (err) {
-    xterm.writeln(`\r\n\x1b[31m终端启动失败: ${err}\x1b[0m`);
+    xterm.writeln(`\r\n\x1b[31m${t("terminalStartFailed", err)}\x1b[0m`);
   }
 }
 
@@ -596,7 +833,7 @@ async function loadPluginCatalog() {
     const res = await fetch(PLUGIN_CATALOG_URL);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    if (!Array.isArray(data.plugins)) throw new Error("响应格式不正确");
+    if (!Array.isArray(data.plugins)) throw new Error(t("invalidResponseFormat"));
     pluginCatalog = data;
     return data;
   })();
@@ -608,7 +845,7 @@ async function loadPluginCatalog() {
 }
 
 function pluginCatalogLang() {
-  return document.documentElement.lang?.toLowerCase().startsWith("zh") ? "zh" : "en";
+  return LANG;
 }
 
 function populateCategoryFilter(categories) {
@@ -616,7 +853,7 @@ function populateCategoryFilter(categories) {
   els.pluginMarketCategory.replaceChildren();
   const allOpt = document.createElement("option");
   allOpt.value = "";
-  allOpt.textContent = "全部分类";
+  allOpt.textContent = t("allCategories");
   els.pluginMarketCategory.appendChild(allOpt);
   for (const [id, names] of Object.entries(categories)) {
     const opt = document.createElement("option");
@@ -655,7 +892,7 @@ function togglePluginSort() {
   pluginSortDirection = pluginSortDirection === "desc" ? "asc" : "desc";
   const icon = pluginSortDirection === "asc" ? "arrow-up" : "arrow-down";
   els.pluginMarketSortIcon.querySelector("use").setAttribute("href", `#icon-${icon}`);
-  els.btnPluginMarketSort.title = pluginSortDirection === "asc" ? "按 star 数从低到高排序" : "按 star 数从高到低排序";
+  els.btnPluginMarketSort.title = pluginSortDirection === "asc" ? t("sortByStarsAsc") : t("sortByStarsDesc");
   renderPluginGrid();
 }
 
@@ -681,11 +918,14 @@ function formatStars(n) {
 function renderPluginGrid() {
   const lang = pluginCatalogLang();
   const results = filteredPlugins();
-  els.pluginMarketStatus.textContent = `${results.length} / ${pluginCatalog.plugins.length} 个插件${
-    results.length > PLUGIN_GRID_RENDER_CAP ? `（仅显示前 ${PLUGIN_GRID_RENDER_CAP} 个，请搜索缩小范围）` : ""
-  }`;
+  els.pluginMarketStatus.textContent = t(
+    "pluginCountStatus",
+    results.length,
+    pluginCatalog.plugins.length,
+    results.length > PLUGIN_GRID_RENDER_CAP
+  );
   if (results.length === 0) {
-    renderPluginGridPlaceholder("inbox", "没有匹配的插件。", false);
+    renderPluginGridPlaceholder("inbox", t("noPluginsMatched"), false);
     return;
   }
   els.pluginMarketGrid.replaceChildren();
@@ -727,7 +967,7 @@ function renderPluginGrid() {
     const btn = document.createElement("button");
     btn.className = "plugin-card-install-btn";
     btn.appendChild(iconEl("download", "icon"));
-    btn.appendChild(document.createTextNode("安装"));
+    btn.appendChild(document.createTextNode(t("install")));
     btn.addEventListener("click", () => openConfirmView(plugin));
     foot.appendChild(cat);
     foot.appendChild(btn);
@@ -758,7 +998,7 @@ function openConfirmView(plugin) {
   const lang = pluginCatalogLang();
   els.pluginConfirmName.textContent = `${plugin.owner}/${plugin.name}`;
   els.pluginConfirmDesc.textContent = plugin.description?.[lang] || plugin.description?.en || "";
-  els.pluginConfirmMeta.textContent = `来源：${plugin.url} · ★ ${formatStars(plugin.stars ?? 0)}`;
+  els.pluginConfirmMeta.textContent = t("sourceMeta", plugin.url, formatStars(plugin.stars ?? 0));
   els.pluginConfirmCmd.textContent = plugin.install;
   els.pluginMarketBrowse.classList.add("hidden");
   els.pluginMarketConfirm.classList.remove("hidden");
@@ -786,7 +1026,7 @@ function setInstallButtonState(icon, label) {
 // actually becomes available without the user having to reopen the dialog.
 async function refreshPnpmGate() {
   els.btnPluginConfirmInstall.disabled = true;
-  setInstallButtonState("loader", "正在检测环境…");
+  setInstallButtonState("loader", t("checkingEnvironment"));
   els.pluginConfirmPnpmMissing.classList.add("hidden");
   let available = false;
   try {
@@ -802,7 +1042,7 @@ async function refreshPnpmGate() {
   if (els.pluginMarketConfirm.classList.contains("hidden")) return;
   els.pluginConfirmPnpmMissing.classList.toggle("hidden", available);
   els.btnPluginConfirmInstall.disabled = !available;
-  setInstallButtonState("download", "确认安装");
+  setInstallButtonState("download", t("confirmInstall"));
 }
 
 function closeConfirmView() {
@@ -836,7 +1076,7 @@ async function openPluginMarket() {
   closeConfirmView();
   if (!pluginCatalog) {
     els.pluginMarketStatus.textContent = "";
-    renderPluginGridPlaceholder("loader", "正在加载插件目录…", true);
+    renderPluginGridPlaceholder("loader", t("loadingCatalog"), true);
   }
   try {
     const data = await loadPluginCatalog();
@@ -844,7 +1084,7 @@ async function openPluginMarket() {
     renderPluginGrid();
   } catch (err) {
     els.pluginMarketStatus.textContent = "";
-    renderPluginGridPlaceholder("alert-circle", `插件目录加载失败: ${err}`, false);
+    renderPluginGridPlaceholder("alert-circle", t("catalogLoadFailed", err), false);
   }
 }
 
@@ -881,7 +1121,7 @@ let pluginInstallButton = null;
 function resetPluginInstallButton() {
   if (!pluginInstallButton) return;
   pluginInstallButton.disabled = false;
-  setInstallButtonState("download", "确认安装");
+  setInstallButtonState("download", t("confirmInstall"));
   pluginInstallButton = null;
 }
 
@@ -893,14 +1133,14 @@ async function installConfirmedPlugin() {
   if (!plugin) return;
   const pkg = packageFromInstallCommand(plugin.install);
   els.btnPluginConfirmInstall.disabled = true;
-  setInstallButtonState("loader", "安装中…");
+  setInstallButtonState("loader", t("installing"));
   pluginInstallButton = els.btnPluginConfirmInstall;
   showPluginInstallLog();
   appendPluginInstallLog(`$ dsh plugin --profile web add ${pkg}`);
   try {
     await invoke("install_plugin", { package: pkg });
   } catch (err) {
-    appendPluginInstallLog(`启动安装失败: ${err}`);
+    appendPluginInstallLog(t("installStartFailed", err));
     resetPluginInstallButton();
   }
   // On success, re-enabling the button happens in the "plugin-install"
@@ -925,7 +1165,7 @@ function setPnpmButtonBusy(busy) {
     .querySelector("use")
     .setAttribute("href", busy ? "#icon-loader" : "#icon-download");
   els.btnPluginInstallPnpmIcon.classList.toggle("icon-spin", busy);
-  els.btnPluginInstallPnpmLabel.textContent = busy ? "安装中…" : "一键安装 pnpm";
+  els.btnPluginInstallPnpmLabel.textContent = busy ? t("installing") : t("installPnpmOneClick");
 }
 
 function resetPnpmInstallButton() {
@@ -948,7 +1188,7 @@ async function installPnpm() {
   try {
     await invoke("install_pnpm");
   } catch (err) {
-    appendPluginInstallLog(`启动安装失败: ${err}`);
+    appendPluginInstallLog(t("installStartFailed", err));
     resetPnpmInstallButton();
   }
   // On success, re-enabling the button and re-probing pnpm both happen in
@@ -1221,7 +1461,7 @@ function setDirty(dirty) {
 // replacing the editor.
 function confirmDiscardIfNeeded() {
   if (!isDirty()) return true;
-  return confirm("有未保存的改动，确定要放弃吗？");
+  return confirm(t("confirmDiscardChanges"));
 }
 
 function destroyEditor() {
@@ -1249,7 +1489,7 @@ function mountEditor(path, preview) {
   if (preview.current === null) {
     const originalText = contentTextOrNull(preview.original);
     if (originalText === null) {
-      els.panelPreviewBody.textContent = "无法读取此文件的历史内容";
+      els.panelPreviewBody.textContent = t("cannotReadHistoricalContent");
       return;
     }
     const extensions = [CM.basicSetup, ...buildCodeMirrorBaseExtensions(), CM.EditorState.readOnly.of(true)];
@@ -1262,11 +1502,11 @@ function mountEditor(path, preview) {
 
   const current = preview.current;
   if (current.kind === "binary") {
-    els.panelPreviewBody.textContent = "二进制文件，无法预览";
+    els.panelPreviewBody.textContent = t("binaryFileNoPreview");
     return;
   }
   if (current.kind === "tooLarge") {
-    els.panelPreviewBody.textContent = `文件过大（${(current.bytes / 1024 / 1024).toFixed(1)} MB），未加载预览`;
+    els.panelPreviewBody.textContent = t("fileTooLarge", (current.bytes / 1024 / 1024).toFixed(1));
     return;
   }
   if (current.kind === "error") {
@@ -1309,7 +1549,7 @@ async function showPreview(path) {
   els.panelPreviewBody.replaceChildren();
   const loading = document.createElement("p");
   loading.className = "muted panel-empty";
-  loading.textContent = "加载中…";
+  loading.textContent = t("loading");
   els.panelPreviewBody.appendChild(loading);
 
   try {
@@ -1321,7 +1561,7 @@ async function showPreview(path) {
     mountEditor(path, preview);
   } catch (err) {
     if (currentPreviewPath !== path) return;
-    els.panelPreviewBody.textContent = `预览加载失败: ${err}`;
+    els.panelPreviewBody.textContent = t("previewLoadFailed", err);
   }
 }
 
@@ -1364,7 +1604,7 @@ function closePreview() {
 
 function revertCurrentEdit() {
   if (!currentEditorView || currentSavedContent === null) return;
-  if (!confirm("放弃当前改动，还原为上次保存的内容？")) return;
+  if (!confirm(t("confirmRevert"))) return;
   currentEditorView.dispatch({
     changes: { from: 0, to: currentEditorView.state.doc.length, insert: currentSavedContent },
   });
@@ -1390,7 +1630,7 @@ async function saveCurrentEdit() {
   } catch (err) {
     // Left exactly as the user typed it on failure — nothing is discarded
     // on a failed write.
-    alert(`保存失败: ${err}`);
+    alert(t("saveFailed", err));
   } finally {
     els.btnPreviewSave.disabled = false;
   }
@@ -1405,7 +1645,7 @@ function renderWorkspaceOptions(knownWorkspaces, autoLabel) {
 
   const autoOption = document.createElement("option");
   autoOption.value = AUTO_OPTION_VALUE;
-  autoOption.textContent = autoLabel ? `自动跟随（${autoLabel}）` : "自动跟随当前会话";
+  autoOption.textContent = autoLabel ? t("autoFollowWithLabel", autoLabel) : t("autoFollowSession");
   select.appendChild(autoOption);
 
   let lockedValueFound = lockedWorkspace === null;
@@ -1470,7 +1710,7 @@ async function refreshTreeAndGitStatus() {
     if (tree.length === 0) {
       const empty = document.createElement("p");
       empty.className = "muted panel-empty";
-      empty.textContent = "空工作区";
+      empty.textContent = t("emptyWorkspace");
       els.panelTree.appendChild(empty);
     } else {
       for (const entry of tree) {
@@ -1478,7 +1718,7 @@ async function refreshTreeAndGitStatus() {
       }
     }
   } catch (err) {
-    els.panelTree.textContent = `无法加载文件树: ${err}`;
+    els.panelTree.textContent = t("treeLoadFailed", err);
   }
 }
 
@@ -1582,7 +1822,7 @@ async function handleFileMention(absPath) {
     els.panelPreviewTitle.textContent = absPath;
     els.panelPreviewTitle.title = absPath;
     els.cardFile.classList.remove("hidden");
-    els.panelPreviewBody.textContent = "该文件不属于任何已知工作区";
+    els.panelPreviewBody.textContent = t("fileNotInKnownWorkspace");
     return;
   }
 
@@ -1617,6 +1857,7 @@ window.addEventListener("message", (event) => {
 // ── init ─────────────────────────────────────────────────────────────────
 
 async function init() {
+  applyStaticTranslations();
   applyPanelWidth();
   initResizeHandle();
   applyCardFileHeight();
@@ -1637,7 +1878,7 @@ async function init() {
     const bits = [];
     if (info.dshVersion) bits.push(`dsh ${info.dshVersion}`);
     if (info.nodePath) bits.push(`Node ${info.nodePath}`);
-    if (info.dshHome) bits.push(`数据目录 ${info.dshHome}`);
+    if (info.dshHome) bits.push(t("dataDirLabel", info.dshHome));
     els.footer.textContent = bits.join(" · ");
   } catch {
     /* footer is cosmetic */
@@ -1647,14 +1888,14 @@ async function init() {
   listen("terminal-data", (event) => xterm?.write(base64ToBytes(event.payload)));
   listen("terminal-exit", () => {
     terminalSpawned = false;
-    xterm?.writeln("\r\n\x1b[90m[进程已结束]\x1b[0m");
+    xterm?.writeln(`\r\n\x1b[90m${t("processExited")}\x1b[0m`);
   });
   listen("plugin-install", (event) => {
     const payload = event.payload;
     if (payload.state === "line") {
       appendPluginInstallLog(payload.text);
     } else if (payload.state === "done") {
-      appendPluginInstallLog(payload.success ? "安装完成。" : `安装失败（exit ${payload.code ?? "?"}）。`);
+      appendPluginInstallLog(payload.success ? t("installComplete") : t("installFailedExit", payload.code ?? "?"));
       resetPluginInstallButton();
     }
   });
@@ -1663,7 +1904,7 @@ async function init() {
     if (payload.state === "line") {
       appendPluginInstallLog(payload.text);
     } else if (payload.state === "done") {
-      appendPluginInstallLog(payload.success ? "pnpm 安装完成。" : `pnpm 安装失败（exit ${payload.code ?? "?"}）。`);
+      appendPluginInstallLog(payload.success ? t("pnpmInstallComplete") : t("pnpmInstallFailedExit", payload.code ?? "?"));
       resetPnpmInstallButton();
       // Re-probe regardless of success/failure — cheap, and covers the case
       // where npm reported non-zero but pnpm actually ended up on PATH
@@ -1675,7 +1916,7 @@ async function init() {
     els.btnRetry.disabled = true;
     invoke("start_server")
       .catch((err) => {
-        els.errorMessage.textContent = `启动失败: ${err}`;
+        els.errorMessage.textContent = t("startFailed", err);
       })
       .finally(() => {
         els.btnRetry.disabled = false;
@@ -1685,7 +1926,7 @@ async function init() {
     els.btnRestart.disabled = true;
     invoke("restart_server")
       .catch((err) => {
-        els.errorMessage.textContent = `重启失败: ${err}`;
+        els.errorMessage.textContent = t("restartFailed", err);
       })
       .finally(() => {
         els.btnRestart.disabled = false;
@@ -1770,15 +2011,15 @@ async function init() {
   });
   els.btnUpdateInstall.addEventListener("click", () => {
     els.btnUpdateInstall.disabled = true;
-    els.btnUpdateInstall.textContent = "正在更新…";
+    els.btnUpdateInstall.textContent = t("updating");
     els.btnUpdateDismiss.disabled = true;
     // On success this relaunches the app (the window disappears); a caught
     // error means the update didn't apply, so restore the button for retry.
     invoke("install_update").catch((err) => {
       els.btnUpdateInstall.disabled = false;
-      els.btnUpdateInstall.textContent = "立即更新";
+      els.btnUpdateInstall.textContent = t("updateNow");
       els.btnUpdateDismiss.disabled = false;
-      els.updateText.textContent = `更新失败: ${err}`;
+      els.updateText.textContent = t("updateFailed", err);
     });
   });
   checkForUpdate();
@@ -1793,7 +2034,7 @@ async function checkForUpdate() {
   try {
     const update = await invoke("check_for_update");
     if (!update) return;
-    els.updateText.textContent = `发现新版本 ${update.version}`;
+    els.updateText.textContent = t("newVersionFound", update.version);
     els.updateBanner.classList.remove("hidden");
   } catch {
     /* update check is best-effort; silent failure keeps the boot page usable offline */

--- a/ui/index.html
+++ b/ui/index.html
@@ -152,50 +152,50 @@
       <div id="toolbar" data-tauri-drag-region>
         <div id="toolbar-left">
           <div id="app-menu-wrap">
-            <button id="btn-app-menu" class="toolbar-btn" title="菜单" aria-haspopup="true" aria-expanded="false">
+            <button id="btn-app-menu" class="toolbar-btn" title="菜单" data-i18n-title="menu" aria-haspopup="true" aria-expanded="false">
               <svg class="icon"><use href="#icon-menu"></use></svg>
             </button>
             <div id="app-menu" class="app-menu hidden" role="menu">
-              <button class="app-menu-item" data-menu-id="open_browser" role="menuitem">在浏览器中打开</button>
-              <button class="app-menu-item" data-menu-id="restart" role="menuitem">重启服务</button>
-              <button class="app-menu-item" data-menu-id="open_data_dir" role="menuitem">打开数据目录</button>
+              <button class="app-menu-item" data-menu-id="open_browser" role="menuitem" data-i18n="openInBrowser">在浏览器中打开</button>
+              <button class="app-menu-item" data-menu-id="restart" role="menuitem" data-i18n="restartService">重启服务</button>
+              <button class="app-menu-item" data-menu-id="open_data_dir" role="menuitem" data-i18n="appMenuOpenDataDir">打开数据目录</button>
               <div class="app-menu-sep"></div>
               <button class="app-menu-item" data-menu-id="toggle_autostart" role="menuitemcheckbox">
                 <svg class="icon app-menu-check hidden"><use href="#icon-check"></use></svg>
-                <span>开机自动启动</span>
+                <span data-i18n="autostartToggle">开机自动启动</span>
               </button>
               <div class="app-menu-sep"></div>
-              <button class="app-menu-item" data-menu-id="quit" role="menuitem">退出</button>
+              <button class="app-menu-item" data-menu-id="quit" role="menuitem" data-i18n="quit">退出</button>
             </div>
           </div>
-          <button id="btn-toolbar-plugins" class="toolbar-btn" title="插件市场">
+          <button id="btn-toolbar-plugins" class="toolbar-btn" title="插件市场" data-i18n-title="pluginMarket">
             <svg class="icon"><use href="#icon-package"></use></svg>
           </button>
         </div>
-        <div id="toolbar-title">探索未至之境</div>
+        <div id="toolbar-title" data-i18n="tagline">探索未至之境</div>
         <div id="toolbar-actions">
-          <button id="btn-toolbar-terminal" class="toolbar-btn" title="终端">
+          <button id="btn-toolbar-terminal" class="toolbar-btn" title="终端" data-i18n-title="terminal">
             <svg class="icon"><use href="#icon-terminal"></use></svg>
           </button>
-          <button id="btn-toolbar-diff" class="toolbar-btn" disabled title="Diff（即将推出）">
+          <button id="btn-toolbar-diff" class="toolbar-btn" disabled title="Diff（即将推出）" data-i18n-title="diffComingSoon">
             <svg class="icon"><use href="#icon-columns"></use></svg>
           </button>
-          <button id="btn-toolbar-files" class="toolbar-btn" title="文件">
+          <button id="btn-toolbar-files" class="toolbar-btn" title="文件" data-i18n-title="files">
             <svg class="icon"><use href="#icon-folder"></use></svg>
           </button>
         </div>
         <div id="window-controls" class="hidden">
-          <button id="btn-win-minimize" class="window-btn" title="最小化">
+          <button id="btn-win-minimize" class="window-btn" title="最小化" data-i18n-title="minimize">
             <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
               <path d="M0 5h10" stroke="currentColor" stroke-width="1" />
             </svg>
           </button>
-          <button id="btn-win-maximize" class="window-btn" title="最大化">
+          <button id="btn-win-maximize" class="window-btn" title="最大化" data-i18n-title="maximize">
             <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
               <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" stroke-width="1" />
             </svg>
           </button>
-          <button id="btn-win-close" class="window-btn window-btn-close" title="关闭">
+          <button id="btn-win-close" class="window-btn window-btn-close" title="关闭" data-i18n-title="close">
             <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
               <path d="M0 0l10 10M10 0L0 10" stroke="currentColor" stroke-width="1" />
             </svg>
@@ -209,8 +209,8 @@
           <div id="update-banner" class="update-banner hidden">
             <span id="update-text"></span>
             <div class="update-actions">
-              <button id="btn-update-install" class="primary">立即更新</button>
-              <button id="btn-update-dismiss">忽略</button>
+              <button id="btn-update-install" class="primary" data-i18n="updateNow">立即更新</button>
+              <button id="btn-update-dismiss" data-i18n="dismiss">忽略</button>
             </div>
           </div>
 
@@ -229,34 +229,34 @@
                 <use class="boot-logo-trace" href="#boot-logo-outline"></use>
               </svg>
             </div>
-            <h1>正在启动 DeepSeek Harness…</h1>
-            <p class="muted" id="starting-detail">准备本地服务</p>
+            <h1 data-i18n="startingTitle">正在启动 DeepSeek Harness…</h1>
+            <p class="muted" id="starting-detail" data-i18n="preparingLocalService">准备本地服务</p>
             <div class="actions">
-              <button id="btn-logs-starting">查看日志</button>
+              <button id="btn-logs-starting" data-i18n="viewLogs">查看日志</button>
             </div>
             <pre id="log-box-starting" class="log hidden"></pre>
 
             <!-- first-run provider tip (non-blocking, shown once, dismissed via localStorage) -->
             <div id="provider-tip" class="provider-tip hidden">
-              <span
+              <span data-i18n="providerTip"
                 >首次使用提示：默认使用 DeepSeek 官方模型。如需接入 OpenAI / Anthropic / Gemini
                 等其他模型，进入后可在「设置 → 模型 → 添加提供方」中配置，随时可改。</span
               >
               <div class="provider-tip-actions">
-                <button id="btn-provider-tip-dismiss">知道了</button>
+                <button id="btn-provider-tip-dismiss" data-i18n="gotIt">知道了</button>
               </div>
             </div>
           </section>
 
           <!-- error -->
           <section id="state-error" class="card hidden">
-            <h1>启动失败</h1>
+            <h1 data-i18n="startupFailed">启动失败</h1>
             <p class="error" id="error-message"></p>
             <div class="actions">
-              <button id="btn-retry" class="primary">重试</button>
-              <button id="btn-restart">重启服务</button>
-              <button id="btn-logs">查看日志</button>
-              <button id="btn-open-browser">在浏览器中打开</button>
+              <button id="btn-retry" class="primary" data-i18n="retry">重试</button>
+              <button id="btn-restart" data-i18n="restartService">重启服务</button>
+              <button id="btn-logs" data-i18n="viewLogs">查看日志</button>
+              <button id="btn-open-browser" data-i18n="openInBrowser">在浏览器中打开</button>
             </div>
             <pre id="log-box" class="log hidden"></pre>
           </section>
@@ -280,18 +280,18 @@
             <div id="dock-view-files">
               <section id="card-files" class="dock-card">
                 <div class="dock-card-header">
-                  <span class="dock-card-title">文件</span>
+                  <span class="dock-card-title" data-i18n="files">文件</span>
                   <div class="dock-card-actions">
-                    <button id="btn-panel-refresh" title="刷新文件树与 Git 状态">
+                    <button id="btn-panel-refresh" title="刷新文件树与 Git 状态" data-i18n-title="refreshTreeTitle">
                       <svg class="icon"><use href="#icon-refresh"></use></svg>
                     </button>
-                    <button id="btn-files-collapse" title="收起">
+                    <button id="btn-files-collapse" title="收起" data-i18n-title="collapse">
                       <svg class="icon"><use href="#icon-chevron-up"></use></svg>
                     </button>
                   </div>
                 </div>
                 <div class="select-wrap">
-                  <select id="panel-workspace-select" title="选择要在文件树中查看的工作区"></select>
+                  <select id="panel-workspace-select" title="选择要在文件树中查看的工作区" data-i18n-title="chooseWorkspaceTitle"></select>
                   <svg class="select-chevron"><use href="#icon-chevron-down"></use></svg>
                 </div>
                 <div id="panel-tree"></div>
@@ -310,12 +310,12 @@
                 <div class="dock-card-header">
                   <div id="panel-preview-title-group">
                     <span id="panel-preview-title"></span>
-                    <span id="panel-preview-dirty-dot" class="hidden" title="有未保存的改动">●</span>
+                    <span id="panel-preview-dirty-dot" class="hidden" title="有未保存的改动" data-i18n-title="unsavedChangesTitle">●</span>
                   </div>
                   <div class="dock-card-actions">
-                    <button id="btn-preview-revert" class="hidden" title="放弃改动，还原为已保存内容">还原</button>
-                    <button id="btn-preview-save" class="hidden" title="保存改动 (Ctrl+S)">保存</button>
-                    <button id="btn-preview-close" title="关闭预览">✕</button>
+                    <button id="btn-preview-revert" class="hidden" title="放弃改动，还原为已保存内容" data-i18n-title="revertTitle" data-i18n="revert">还原</button>
+                    <button id="btn-preview-save" class="hidden" title="保存改动 (Ctrl+S)" data-i18n-title="saveTitle" data-i18n="save">保存</button>
+                    <button id="btn-preview-close" title="关闭预览" data-i18n-title="closePreviewTitle">✕</button>
                   </div>
                 </div>
                 <div id="panel-preview-body"></div>
@@ -324,12 +324,12 @@
 
             <section id="card-terminal" class="dock-card hidden">
               <div class="dock-card-header">
-                <span class="dock-card-title">终端</span>
+                <span class="dock-card-title" data-i18n="terminal">终端</span>
                 <div class="dock-card-actions">
-                  <button id="btn-terminal-restart" title="重启终端">
+                  <button id="btn-terminal-restart" title="重启终端" data-i18n-title="restartTerminalTitle">
                     <svg class="icon"><use href="#icon-refresh"></use></svg>
                   </button>
-                  <button id="btn-terminal-close" title="关闭终端">✕</button>
+                  <button id="btn-terminal-close" title="关闭终端" data-i18n-title="closeTerminalTitle">✕</button>
                 </div>
               </div>
               <div id="terminal-container"></div>
@@ -361,10 +361,10 @@
         <div class="dock-card-header">
           <span id="plugin-market-title" class="dock-card-title dock-card-title-icon">
             <svg class="icon"><use href="#icon-package"></use></svg>
-            插件市场
+            <span data-i18n="pluginMarket">插件市场</span>
           </span>
           <div class="dock-card-actions">
-            <button id="btn-plugin-market-close" title="关闭">
+            <button id="btn-plugin-market-close" title="关闭" data-i18n-title="close">
               <svg class="icon"><use href="#icon-x"></use></svg>
             </button>
           </div>
@@ -375,7 +375,7 @@
           <div id="plugin-market-toolbar">
             <div id="plugin-market-search-wrap" class="input-icon-wrap">
               <svg class="input-icon"><use href="#icon-search"></use></svg>
-              <input id="plugin-market-search" type="search" placeholder="搜索插件名称或描述…" autocomplete="off" />
+              <input id="plugin-market-search" type="search" placeholder="搜索插件名称或描述…" data-i18n-placeholder="pluginSearchPlaceholder" autocomplete="off" />
             </div>
             <div class="select-wrap select-wrap-inline">
               <select id="plugin-market-category"></select>
@@ -388,7 +388,7 @@
               first already), so there's no third "unsorted" state to cycle
               through, just these two.
             -->
-            <button id="btn-plugin-market-sort" class="plugin-market-sort-btn" title="按 star 数排序">
+            <button id="btn-plugin-market-sort" class="plugin-market-sort-btn" title="按 star 数排序" data-i18n-title="sortByStarsTitle">
               <svg class="icon"><use href="#icon-star"></use></svg>
               <svg id="plugin-market-sort-icon" class="icon"><use href="#icon-arrow-down"></use></svg>
             </button>
@@ -408,7 +408,7 @@
         <div id="plugin-market-confirm" class="hidden">
           <button id="btn-plugin-confirm-back" class="link-back">
             <svg class="icon"><use href="#icon-chevron-right"></use></svg>
-            返回列表
+            <span data-i18n="backToList">返回列表</span>
           </button>
           <h3 id="plugin-confirm-name"></h3>
           <p id="plugin-confirm-desc" class="muted"></p>
@@ -416,12 +416,12 @@
           <div class="plugin-confirm-warning">
             <svg class="plugin-confirm-warning-icon"><use href="#icon-alert-triangle"></use></svg>
             <span>
-              <strong>安装第三方插件存在风险。</strong>
-              插件会以当前用户权限运行第三方代码，可读取本机文件、使用你的登录凭据、访问网络，安装/审批环节不会对其进行沙箱隔离。来源仓库的构建脚本也会在安装时执行。仅安装你信任的来源。
+              <strong data-i18n="pluginRiskTitle">安装第三方插件存在风险。</strong>
+              <span data-i18n="pluginRiskBody">插件会以当前用户权限运行第三方代码，可读取本机文件、使用你的登录凭据、访问网络，安装/审批环节不会对其进行沙箱隔离。来源仓库的构建脚本也会在安装时执行。仅安装你信任的来源。</span>
             </span>
           </div>
           <div id="plugin-confirm-cmd-wrap">
-            <span class="dock-card-title">将执行的命令</span>
+            <span class="dock-card-title" data-i18n="commandToRun">将执行的命令</span>
             <code id="plugin-confirm-cmd"></code>
           </div>
           <!--
@@ -435,33 +435,33 @@
           <div id="plugin-confirm-pnpm-missing" class="plugin-confirm-warning plugin-confirm-warning-pnpm hidden">
             <svg class="plugin-confirm-warning-icon"><use href="#icon-alert-circle"></use></svg>
             <span>
-              <strong>未检测到 pnpm。</strong>
-              插件安装依赖 pnpm，请先安装后再继续。
+              <strong data-i18n="pnpmNotFoundTitle">未检测到 pnpm。</strong>
+              <span data-i18n="pnpmNotFoundBody">插件安装依赖 pnpm，请先安装后再继续。</span>
               <div class="actions plugin-confirm-pnpm-actions">
                 <button id="btn-plugin-install-pnpm">
                   <svg id="btn-plugin-install-pnpm-icon" class="icon"><use href="#icon-download"></use></svg>
-                  <span id="btn-plugin-install-pnpm-label">一键安装 pnpm</span>
+                  <span id="btn-plugin-install-pnpm-label" data-i18n="installPnpmOneClick">一键安装 pnpm</span>
                 </button>
               </div>
             </span>
           </div>
           <div class="actions plugin-confirm-actions">
-            <button id="btn-plugin-confirm-source" title="在浏览器中查看来源仓库">
+            <button id="btn-plugin-confirm-source" title="在浏览器中查看来源仓库" data-i18n-title="viewSourceTitle">
               <svg class="icon"><use href="#icon-external-link"></use></svg>
-              查看来源
+              <span data-i18n="viewSource">查看来源</span>
             </button>
             <button id="btn-plugin-confirm-install" class="primary">
               <svg id="btn-plugin-confirm-install-icon" class="icon"><use href="#icon-download"></use></svg>
-              <span id="btn-plugin-confirm-install-label">确认安装</span>
+              <span id="btn-plugin-confirm-install-label" data-i18n="confirmInstall">确认安装</span>
             </button>
           </div>
         </div>
 
         <div id="plugin-install-log-wrap" class="hidden">
           <div class="dock-card-header">
-            <span class="dock-card-title">安装日志</span>
+            <span class="dock-card-title" data-i18n="installLog">安装日志</span>
             <div class="dock-card-actions">
-              <button id="btn-plugin-install-log-close" title="关闭">
+              <button id="btn-plugin-install-log-close" title="关闭" data-i18n-title="close">
                 <svg class="icon"><use href="#icon-x"></use></svg>
               </button>
             </div>


### PR DESCRIPTION
## Summary
- Fixes #23 — the system tray menu, macOS app menu, OS notifications, and the entire `ui/` dock (boot/error screens, toolbar, file panel, terminal, plugin market) were hardcoded Chinese regardless of the OS display language. This was independent of, and unaffected by, the harness web UI's own `locale.preference` setting.
- Adds OS-locale-driven bilingual (zh/en) support on both sides of the native shell, each detecting locale independently using the same rule the harness's own locale service uses (positively-detected English → English, everything else → Chinese fallback):
  - **Native/Rust** (`src-tauri/src/i18n.rs`, new module): `sys_locale::get_locale()` + a small `tr()` helper, applied to the tray menu and macOS app menu (`menu.rs`), the background-notification and update-check error text (`lib.rs`), every status/error string shown on the boot/error screen plus the tray tooltip (`server.rs`), and the file-preview/save error messages (`panel.rs`).
  - **Frontend** (`ui/app.js`): `navigator.language` + a `STRINGS`/`t()` dictionary (~90 keys), wired into `index.html` via `data-i18n`/`data-i18n-title`/`data-i18n-placeholder` attributes for static markup, and into every dynamic string in `app.js`.
- Deliberately out of scope: the free-form diagnostic log tail (the "View Logs" panel, fed by `push_log`) stays Chinese — translating every interpolated log line is a much larger, lower-value job than the primary UI text this covers, and it's opt-in debug scrollback, not primary chrome. Documented in `i18n.rs`'s module doc comment and in `CLAUDE.md`.
- The two detection paths (native Rust vs. web JS) are intentionally independent — the harness page in the iframe has zero Tauri IPC access (see `lib.rs`'s module doc comment), so there's no channel for this shell to read its `locale.preference` through, and no reason to invent one just for this. Also documented in `CLAUDE.md` so this isn't re-litigated later.

## Test plan
- [x] `cargo build` — compiles clean (one pre-existing, unrelated warning on Windows: `menu.rs`'s `PredefinedMenuItem` import is only used by the macOS-only `build_menu`)
- [x] `cargo test` — all 32 existing tests pass
- [x] `node --check ui/app.js` — no syntax errors
- [x] Swept every changed file for leftover raw Chinese text outside the `STRINGS.zh`/`i18n::tr` dictionaries and code comments — none found
- [ ] Manual verification in a real English-display-language Windows session (tray menu, boot screen, dock) — not done by me per this repo's own testing convention (native-window changes are verified by a human in the real window, not by automated screenshotting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)