### PR TITLE
chore: bump version to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui"


### PR DESCRIPTION
Covers the native-shell locale fix (#24 — tray/menu/boot screen/dock now respect OS language), the only change merged since v1.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)