### PR TITLE
chore: bump pinned dsh runtime to 0.1.0-rc.8

### DIFF
--- a/docs/DEVELOPMENT.en.md
+++ b/docs/DEVELOPMENT.en.md
@@ -30,7 +30,7 @@ so it is fast and offline after the first run.
 | `DSH_DESKTOP_NODE` | Absolute path to `node.exe` to use instead of the one on `PATH` |
 | `DSH_DESKTOP_DSH_BIN` | Absolute path to a `dsh` `lib/bin.js` (e.g. a local checkout) |
 | `DSH_DESKTOP_RUNTIME_DIR` | Where the managed `@deepseek-ai/dsh` runtime is installed (default: app cache dir); point it at an existing `node_modules` root to skip the first-run npm install |
-| `DSH_DESKTOP_DSH_VERSION` | npm version spec for the managed runtime (default `0.1.0-rc.7`) |
+| `DSH_DESKTOP_DSH_VERSION` | npm version spec for the managed runtime (default `0.1.0-rc.8`) |
 | `DSH_DESKTOP_PORT` | Default bind port override (default `3080`); handy for running several instances |
 | `DSH_DESKTOP_CWD` | Working directory for the `dsh` server process (default: user home) |
 | `DSH_HOME` | Passed through to the server; harness data root (default `~/.dsh`) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,7 +30,7 @@ npm run tauri dev    # 编译 Rust 外壳并打开应用窗口
 | `DSH_DESKTOP_NODE` | 指定 `node.exe` 的绝对路径，代替 `PATH` 上那个 |
 | `DSH_DESKTOP_DSH_BIN` | 指定某个 `dsh` `lib/bin.js` 的绝对路径（比如本地某个 checkout） |
 | `DSH_DESKTOP_RUNTIME_DIR` | 托管的 `@deepseek-ai/dsh` 运行时安装位置（默认是应用缓存目录）；指向一个已有的 `node_modules` 根目录可以跳过首次的 npm install |
-| `DSH_DESKTOP_DSH_VERSION` | 托管运行时使用的 npm 版本号（默认 `0.1.0-rc.7`） |
+| `DSH_DESKTOP_DSH_VERSION` | 托管运行时使用的 npm 版本号（默认 `0.1.0-rc.8`） |
 | `DSH_DESKTOP_PORT` | 默认绑定端口覆盖（默认 `3080`）；同时跑多个实例时很有用 |
 | `DSH_DESKTOP_CWD` | `dsh` 服务进程的工作目录（默认是用户主目录） |
 | `DSH_HOME` | 透传给服务端；harness 数据根目录（默认 `~/.dsh`） |

--- a/scripts/prepare-runtime.mjs
+++ b/scripts/prepare-runtime.mjs
@@ -4,7 +4,7 @@
 // milestone.
 //
 // Usage: node scripts/prepare-runtime.mjs
-// Env:   DSH_DESKTOP_DSH_VERSION  npm version spec (default 0.1.0-rc.7)
+// Env:   DSH_DESKTOP_DSH_VERSION  npm version spec (default 0.1.0-rc.8)
 //        DSH_RUNTIME_SOURCE       directory containing node_modules/@deepseek-ai/dsh
 //                                 (e.g. an existing npx cache root) — copies it
 //                                 locally instead of hitting the npm registry.
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const runtimeDir = join(root, "src-tauri", "resources", "runtime");
-const version = process.env.DSH_DESKTOP_DSH_VERSION ?? "0.1.0-rc.7";
+const version = process.env.DSH_DESKTOP_DSH_VERSION ?? "0.1.0-rc.8";
 mkdirSync(runtimeDir, { recursive: true });
 
 const source = process.env.DSH_RUNTIME_SOURCE;

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -39,7 +39,7 @@ pub const TRAY_ID: &str = "main-tray";
 pub const DEFAULT_PORT: u16 = 3080;
 
 /// Default npm version spec for the managed `@deepseek-ai/dsh` runtime.
-const DSH_VERSION_DEFAULT: &str = "0.1.0-rc.7";
+const DSH_VERSION_DEFAULT: &str = "0.1.0-rc.8";
 /// Marker found verbatim in the harness index page (served uncompressed).
 const INDEX_MARKER: &str = "DeepSeek Harness";
 /// Max lines kept in the in-memory log ring buffer.
@@ -1034,11 +1034,16 @@ fn spawn(app: &AppHandle, server: &Shared, node: &str, bin: &str, port: u16) -> 
 
     push_log(
         server,
-        format!("启动: {node} {bin} web --port {port}  (cwd: {cwd_plain})"),
+        format!("启动: {node} {bin} web --port {port} --no-open  (cwd: {cwd_plain})"),
     );
 
     let mut cmd = Command::new(node);
-    cmd.arg(bin).arg("web").arg("--port").arg(port.to_string());
+    // --no-open: dsh 0.1.0-rc.8 added opening the host's default browser on
+    // `dsh web` startup (outside SSH). This shell is the intended surface —
+    // the harness page is loaded into our own window via the iframe above —
+    // so an extra system browser tab popping open alongside it is a visible
+    // regression, not a feature this app wants.
+    cmd.arg(bin).arg("web").arg("--port").arg(port.to_string()).arg("--no-open");
     cmd.current_dir(&cwd_plain);
     // See `effective_path`: every tool call dsh shells out to on the
     // agent's behalf inherits this, so a stale/truncated PATH here doesn't


### PR DESCRIPTION
## Summary
- `@deepseek-ai/dsh` published `0.1.0-rc.8` on 2026-08-19, one day after the currently-pinned `0.1.0-rc.7` — `release.yml`'s `check:dsh-version` gate caught this and failed the v1.5.0 release run before it built anything.
- Bumps `DSH_VERSION_DEFAULT` (server.rs) and the `prepare-runtime.mjs` default together (both required to agree, per `scripts/check-dsh-version.mjs`), plus the two docs mentioning the default.
- rc.8's changelog headline changes relevant to this wrapper:
  - **`dsh web` now opens the host's default browser on startup** (outside SSH) — verified against upstream source (`packages/bundle/web-app` README/startup.ts in deepseek-ai/deepseek-harness): a `--no-open` flag suppresses it per-invocation. Added `.arg("--no-open")` to the `dsh web --port <port>` spawn in `server.rs` so this doesn't pop an extra browser window next to the app's own window every launch.
  - **SQLite storage format is incompatible** with prior versions. This is upstream's own migration path for `~/.dsh` and isn't something verifiable from this repo — noted in the commit message for visibility, not mitigated here.

## Test plan
- [x] `cargo check --no-default-features` / `cargo test --no-default-features` (50 tests) pass
- [x] `server.rs` and `prepare-runtime.mjs` pins agree (`0.1.0-rc.8`)
- [ ] CI's `prepare-runtime`/`bundle-smoke-test` jobs exercise a real install of rc.8 — this is the first real verification that the new version actually installs cleanly under this project's exact `npm install --prefix ...` invocation
- [ ] Manual: launch the app and confirm no extra browser window opens on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)