### PR TITLE
fix: raise npm's heap ceiling to stop macOS prepare-runtime OOM crashes

### DIFF
--- a/scripts/prepare-runtime.mjs
+++ b/scripts/prepare-runtime.mjs
@@ -39,7 +39,17 @@ if (sourceBin && existsSync(sourceBin)) {
   // the shell-escaping caveat that comes with `shell: true` doesn't apply.
   execFileSync(
     `npm install --prefix "${runtimeDir}" "@deepseek-ai/dsh@${version}" --omit=dev --no-audit --no-fund --no-progress --prefer-offline --fetch-retries=5 --fetch-retry-mintimeout=2000`,
-    { stdio: "inherit", shell: true },
+    {
+      stdio: "inherit",
+      shell: true,
+      // macos-latest CI runners are 7GB total; V8's auto-sized heap ceiling
+      // (~2GB there) is too tight to resolve this dependency tree with no
+      // lockfile to shortcut against, and reliably crashes with "JavaScript
+      // heap out of memory" instead of completing. 4096 leaves real headroom
+      // under the runner's actual ceiling — the commonly-suggested 8192
+      // would exceed this runner's total physical memory outright.
+      env: { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --max-old-space-size=4096`.trim() },
+    },
   );
 }
 


### PR DESCRIPTION
## Summary
- `prepare-runtime.mjs`'s `npm install --prefix ...` crashes with `JavaScript heap out of memory` on `macos-latest` CI runners — reproduced across the last several rc.7 and rc.8 CI/release runs (see HANDOFF.md).
- Root cause: `macos-latest` (arm64) hosted runners are 7GB total RAM; V8 auto-sizes its heap ceiling to ~2GB there, and resolving this dependency tree with no lockfile to shortcut against needs more than that. Not version-specific, not a real Node/npm bug — every failed run hits the identical `FATAL ERROR: ... heap out of memory` at ~2020-2032MB, and one earlier rc.7 release (v1.4.1, 2026-08-18) happened to succeed, consistent with a resource-margin problem rather than a deterministic incompatibility.
- Fix: scope `NODE_OPTIONS=--max-old-space-size=4096` to just that one `execFileSync` call. 4096 (not the commonly-suggested 8192, which exceeds this runner's total physical memory) leaves real headroom under the runner's actual ~7GB ceiling.

## Test plan
- [ ] CI's `prepare-runtime (macos-latest)` job passes
- [ ] CI's `bundle-smoke-test (macos-latest, dmg, ...)` job passes
- [ ] `prepare-runtime (ubuntu-latest)` and `prepare-runtime-windows` still pass (unaffected platforms, regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)