### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui"


### PR DESCRIPTION
## Summary
- Re-releases v1.5.0's content plus the macOS `prepare-runtime` OOM fix (#30 / 24cc916) so `macos-release` can finally produce a `.dmg`.
- Windows/Linux are functionally unchanged from v1.5.0 — this is purely to get all three platforms out of the same tag/release.

## Test plan
- [ ] CI green on this PR (all platforms)
- [ ] After merge, tag v1.5.1 and confirm release.yml's `release` (Windows), `macos-release`, `linux-release` all succeed
- [ ] Release has Windows exe + latest.json + macOS dmg + Linux deb attached