### PR TITLE
fix(scripts): harden sync-upstream.sh install step on macOS (kill process tree, release port, verify after launch)

### DIFF
--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -50,21 +50,28 @@ IS_MACOS=0
 
 # 进程/端口检测辅助函数（ps/lsof 实现；不用 pgrep/pkill——实测部分环境
 # pgrep -f 匹配不可靠，进程明明在跑却匹配不到，会导致清理失败、端口冲突）。
+# 每个函数末尾的 `|| true`：管道中间的 grep 在"没匹配到"时以状态 1 结束，
+# pipefail 下这会成为整条管道的退出码——"没找到进程"是这些函数最常见、
+# 完全正常的结果，不该被当成失败。这在 `for x in $(fn)` 或
+# `if [ -n "$(fn)" ]` 里不会出问题（那些上下文本就不受 errexit 影响），
+# 但一旦哪天改成 `X="$(fn)"` 这种裸赋值调用，没有 `|| true` 就会在"进程
+# 已经不在了"这个最常见的情况下，被 set -e 直接静默杀掉整个脚本、不打印
+# 任何错误——这正是启动后校验那段代码原本会撞上的坑。
 find_main_pids() { # 主进程 PID 列表
-  ps -axo pid=,args= | grep -F "/Applications/$APP_NAME/Contents/MacOS/$PRODUCT_NAME" | grep -v grep | awk '{print $1}'
+  ps -axo pid=,args= | grep -F "/Applications/$APP_NAME/Contents/MacOS/$PRODUCT_NAME" | grep -v grep | awk '{print $1}' || true
 }
 find_runtime_pids() { # runtime web 服务（孤儿化后仍占端口）PID 列表
-  ps -axo pid=,args= | grep -F "/Applications/$APP_NAME/Contents/Resources/runtime" | grep -v grep | awk '{print $1}'
+  ps -axo pid=,args= | grep -F "/Applications/$APP_NAME/Contents/Resources/runtime" | grep -v grep | awk '{print $1}' || true
 }
 # 探测 dsh web 服务实际使用的端口（优先从运行中的 web 进程命令行取，取不到回退 3080）
 find_web_port() {
   local port
   port="$(ps -axo args= | grep -F "/Applications/$APP_NAME/Contents/Resources/runtime" | grep -v grep \
-    | sed -nE 's/.*--port[ =]([0-9]+).*/\1/p' | head -1)"
+    | sed -nE 's/.*--port[ =]([0-9]+).*/\1/p' | head -1)" || true
   [ -n "$port" ] && echo "$port" || echo 3080
 }
 port_owner() { # 指定端口占用者 PID
-  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null
+  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null || true
 }
 
 echo "==> 1/6 拉取上游最新提交"

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -48,6 +48,25 @@ APP_NAME="$PRODUCT_NAME.app"
 IS_MACOS=0
 [ "$(uname)" = "Darwin" ] && IS_MACOS=1
 
+# 进程/端口检测辅助函数（ps/lsof 实现；不用 pgrep/pkill——实测部分环境
+# pgrep -f 匹配不可靠，进程明明在跑却匹配不到，会导致清理失败、端口冲突）。
+find_main_pids() { # 主进程 PID 列表
+  ps -axo pid=,args= | grep -F "/Applications/$APP_NAME/Contents/MacOS/$PRODUCT_NAME" | grep -v grep | awk '{print $1}'
+}
+find_runtime_pids() { # runtime web 服务（孤儿化后仍占端口）PID 列表
+  ps -axo pid=,args= | grep -F "/Applications/$APP_NAME/Contents/Resources/runtime" | grep -v grep | awk '{print $1}'
+}
+# 探测 dsh web 服务实际使用的端口（优先从运行中的 web 进程命令行取，取不到回退 3080）
+find_web_port() {
+  local port
+  port="$(ps -axo args= | grep -F "/Applications/$APP_NAME/Contents/Resources/runtime" | grep -v grep \
+    | sed -nE 's/.*--port[ =]([0-9]+).*/\1/p' | head -1)"
+  [ -n "$port" ] && echo "$port" || echo 3080
+}
+port_owner() { # 指定端口占用者 PID
+  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null
+}
+
 echo "==> 1/6 拉取上游最新提交"
 git fetch origin
 
@@ -126,12 +145,59 @@ if [ "$DO_INSTALL" -eq 1 ] && [ "$IS_MACOS" -eq 1 ]; then
     echo "中止：未找到有效的新构建产物 $BUNDLE ——旧安装保持不变。" >&2
     exit 1
   fi
-  echo "==> 6/6 退出运行中的实例并替换 /Applications"
+  echo "==> 6/6 彻底退出运行中的实例并替换 /Applications"
+  # 与 CLAUDE.md 里 Windows 侧 "taskkill /F /T" 同样的原则：必须连子进程一起清理。
+  # dsh-desktop 退出后，其 runtime/node web 服务子进程可能变孤儿继续占端口，
+  # 而应用又有"服务挂了自动重启"机制——只退主进程会让新旧实例抢端口、反复拉起。
   osascript -e "tell application \"$PRODUCT_NAME\" to quit" 2>/dev/null || true
   sleep 2
+  for pid in $(find_main_pids) $(find_runtime_pids); do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  done
+  sleep 2
+  WEB_PORT="$(find_web_port)"
+  if [ -n "$(port_owner "$WEB_PORT")" ]; then
+    echo "    端口 $WEB_PORT 仍被占用，强制清理残留进程..."
+    for pid in $(port_owner "$WEB_PORT"); do
+      [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    done
+    sleep 2
+  fi
+  # 启动前确认：旧实例完全退出、端口释放（最多等 5 秒），否则中止——绝不对
+  # 运行中的实例做覆盖安装。
+  for i in 1 2 3 4 5; do
+    if [ -z "$(find_main_pids)" ] && [ -z "$(port_owner "$WEB_PORT")" ]; then
+      break
+    fi
+    sleep 1
+  done
+  if [ -n "$(find_main_pids)" ]; then
+    echo "中止：旧实例未能完全退出（请手动退出后重试），旧安装保持不变。" >&2
+    exit 1
+  fi
+  echo "    旧实例已完全退出，端口已释放"
   rm -rf "/Applications/$APP_NAME"
   cp -R "$BUNDLE" /Applications/
   open "/Applications/$APP_NAME"
+  # 启动后校验：新进程存在、Web 服务就绪（最多等 15 秒）
+  sleep 3
+  for i in 1 2 3 4 5 6; do
+    [ -n "$(port_owner "$WEB_PORT")" ] && break
+    sleep 2
+  done
+  NEW_PIDS="$(find_main_pids)"
+  if [ -z "$NEW_PIDS" ]; then
+    echo "    警告：未检测到新版进程，可能需要手动打开应用"
+  else
+    COUNT="$(echo "$NEW_PIDS" | wc -l | tr -d ' ')"
+    echo "    新版进程已运行 (PID: $(echo "$NEW_PIDS" | tr '\n' ' '))"
+    [ "$COUNT" -gt 1 ] && echo "    警告：检测到多个进程实例，若界面异常请重启应用"
+  fi
+  if [ -n "$(port_owner "$WEB_PORT")" ]; then
+    echo "    Web 界面服务已就绪 (端口 $WEB_PORT)"
+  else
+    echo "    警告：端口 $WEB_PORT 尚未就绪，请稍后刷新页面；若长时间无响应请重启应用"
+  fi
   echo "    完成：新版本已安装并启动"
 elif [ "$DO_INSTALL" -eq 1 ]; then
   echo "==> 6/6 当前平台不自动安装，请手动使用构建产物"


### PR DESCRIPTION
## Problem

On macOS, when the desktop shell (`dsh-desktop`) exits, its child `runtime/node ... web` process can survive as an orphan and keep listening on its port (I reproduced this live: main process gone, `PPID=1` node still holding port 3080). Since the app also auto-restarts a crashed web service, the current install step in `sync-upstream.sh` is fragile:

```bash
osascript -e "tell application ... to quit"   # only quits the main process
sleep 2
rm -rf "/Applications/...app"
cp -R "$BUNDLE" /Applications/
open "/Applications/...app"
```

Symptoms when updating:

- The old web service keeps the port; the new instance either fails to bind, or the app auto-restarts the stale service → new/old instances fighting over the port, repeated relaunch loops, broken UI.
- `pgrep`/`pkill` matching proved unreliable in this environment (`ps` sees the process, `pgrep -f` does not), so process management needs `ps` + `lsof`.

This is the same principle the repo already documents for Windows ("`taskkill` must be `/F /T` — without `/T` it leaves an orphaned `dsh` Node service") — the macOS install path was missing the equivalent.

## Changes

Harden step 6/6 of `scripts/sync-upstream.sh` (macOS install):

1. Kill the **whole process tree** — main process + `runtime/` children — using `ps`-based lookup instead of `pgrep`/`pkill`.
2. Detect the actual web port from the running process (fallback 3080) and **force-release it** if still occupied (orphans / auto-restart leftovers).
3. **Abort before installing** if the old instance cannot be fully stopped (max 5s wait) — never overwrite a live install.
4. **Verify after launch**: new process present, web service listening (max 15s wait), and warn on duplicate instances.

## Verification

- Helper functions tested live against a real orphan scenario (stale node holding the port is found and identified).
- `bash -n` syntax check passes.
- The same hardened logic has been in daily use as a standalone macOS update script (1.4.0 → 1.5.1 update path).

## Notes

- This affects the maintainer/dev workflow (`sync-upstream.sh`), not just end users.
- Long-term, macOS auto-update via `latest.json` still needs Apple code signing/notarization (as `release.yml` comments already note) — this patch is the pragmatic fix in the meantime.
