### PR TITLE
chore: bump version to 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui",


### PR DESCRIPTION
## Summary
- Bumps shell version `1.5.1 → 1.5.2` in `package.json` and `tauri.conf.json`.
- 1.5.2 ships the merged fixes from this session: bundled-runtime-version-drift fix (#33), the rc.7 revert with the `check-dsh-version.mjs` dist-tag fix, and the macOS `sync-upstream.sh` hardening (#32).
- Crate version stays `0.3.0` (matches prior releases — it tracks the crate, not the product; tauri.conf.json's `version` is the updater/NSIS version).

Tested locally: installer builds and launches (user verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)