### PR TITLE
chore: bump version to 1.5.3 (dsh runtime 0.1.1-rc.2)

### DIFF
--- a/docs/DEVELOPMENT.en.md
+++ b/docs/DEVELOPMENT.en.md
@@ -30,7 +30,7 @@ so it is fast and offline after the first run.
 | `DSH_DESKTOP_NODE` | Absolute path to `node.exe` to use instead of the one on `PATH` |
 | `DSH_DESKTOP_DSH_BIN` | Absolute path to a `dsh` `lib/bin.js` (e.g. a local checkout) |
 | `DSH_DESKTOP_RUNTIME_DIR` | Where the managed `@deepseek-ai/dsh` runtime is installed (default: app cache dir); point it at an existing `node_modules` root to skip the first-run npm install |
-| `DSH_DESKTOP_DSH_VERSION` | npm version spec for the managed runtime (default `0.1.0-rc.7`) |
+| `DSH_DESKTOP_DSH_VERSION` | npm version spec for the managed runtime (default `0.1.1-rc.2`) |
 | `DSH_DESKTOP_PORT` | Default bind port override (default `3080`); handy for running several instances |
 | `DSH_DESKTOP_CWD` | Working directory for the `dsh` server process (default: user home) |
 | `DSH_HOME` | Passed through to the server; harness data root (default `~/.dsh`) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,7 +30,7 @@ npm run tauri dev    # 编译 Rust 外壳并打开应用窗口
 | `DSH_DESKTOP_NODE` | 指定 `node.exe` 的绝对路径，代替 `PATH` 上那个 |
 | `DSH_DESKTOP_DSH_BIN` | 指定某个 `dsh` `lib/bin.js` 的绝对路径（比如本地某个 checkout） |
 | `DSH_DESKTOP_RUNTIME_DIR` | 托管的 `@deepseek-ai/dsh` 运行时安装位置（默认是应用缓存目录）；指向一个已有的 `node_modules` 根目录可以跳过首次的 npm install |
-| `DSH_DESKTOP_DSH_VERSION` | 托管运行时使用的 npm 版本号（默认 `0.1.0-rc.7`） |
+| `DSH_DESKTOP_DSH_VERSION` | 托管运行时使用的 npm 版本号（默认 `0.1.1-rc.2`） |
 | `DSH_DESKTOP_PORT` | 默认绑定端口覆盖（默认 `3080`）；同时跑多个实例时很有用 |
 | `DSH_DESKTOP_CWD` | `dsh` 服务进程的工作目录（默认是用户主目录） |
 | `DSH_HOME` | 透传给服务端；harness 数据根目录（默认 `~/.dsh`） |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/scripts/prepare-runtime.mjs
+++ b/scripts/prepare-runtime.mjs
@@ -4,7 +4,7 @@
 // milestone.
 //
 // Usage: node scripts/prepare-runtime.mjs
-// Env:   DSH_DESKTOP_DSH_VERSION  npm version spec (default 0.1.0-rc.7)
+// Env:   DSH_DESKTOP_DSH_VERSION  npm version spec (default 0.1.1-rc.2)
 //        DSH_RUNTIME_SOURCE       directory containing node_modules/@deepseek-ai/dsh
 //                                 (e.g. an existing npx cache root) — copies it
 //                                 locally instead of hitting the npm registry.
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const runtimeDir = join(root, "src-tauri", "resources", "runtime");
-const version = process.env.DSH_DESKTOP_DSH_VERSION ?? "0.1.0-rc.7";
+const version = process.env.DSH_DESKTOP_DSH_VERSION ?? "0.1.1-rc.2";
 mkdirSync(runtimeDir, { recursive: true });
 
 const source = process.env.DSH_RUNTIME_SOURCE;

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -39,7 +39,7 @@ pub const TRAY_ID: &str = "main-tray";
 pub const DEFAULT_PORT: u16 = 3080;
 
 /// Default npm version spec for the managed `@deepseek-ai/dsh` runtime.
-const DSH_VERSION_DEFAULT: &str = "0.1.0-rc.7";
+const DSH_VERSION_DEFAULT: &str = "0.1.1-rc.2";
 /// Marker found verbatim in the harness index page (served uncompressed).
 const INDEX_MARKER: &str = "DeepSeek Harness";
 /// Max lines kept in the in-memory log ring buffer.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui",


### PR DESCRIPTION
- Bump pinned `@deepseek-ai/dsh` runtime to `0.1.1-rc.2` — npm `latest` finally moved past `0.1.0-rc.7` (2026-08-21), per the version policy in `docs/DEVELOPMENT.md`
- Bump shell version to 1.5.3 (package.json + tauri.conf.json)
- v1.5.3 tag already pushed → release workflow builds artifacts into a draft release

Co-Authored-By: Claude <noreply@anthropic.com>