### PR TITLE
feat: extend window controls to the screen edge

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,9 @@ webview2-com = "0.38"
 # effective_path in server.rs to resolve %VAR% placeholders (e.g.
 # %NVM_SYMLINK%) that show up literally in registry PATH values — winreg's
 # own get_value reads REG_EXPAND_SZ as a plain string and never expands it.
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Environment"] }
+# Win32_UI_WindowsAndMessaging + Win32_UI_Shell: the window-procedure
+# subclasses in window_proc.rs (maximized frameless-window hit-test fix).
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Environment", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell"] }
 # Reads the registry's real user+machine PATH — see `effective_path` in
 # server.rs.
 winreg = "0.52"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ mod menu;
 mod panel;
 mod server;
 mod terminal;
+#[cfg(windows)]
+mod window_proc;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -941,6 +943,11 @@ pub fn run() {
                 allow_clipboard_permission(&win);
                 inject_file_mention_bridge(&win);
                 install_external_link_handlers(&handle, &win);
+                // Windows-only: makes the maximized window's top strip
+                // deliver hover/click to the web content instead of a
+                // resize cursor — see window_proc.rs.
+                #[cfg(windows)]
+                window_proc::patch_maximized_hit_test(&win);
             }
 
             // `decorations: false` in tauri.conf.json gives the frameless

--- a/src-tauri/src/window_proc.rs
+++ b/src-tauri/src/window_proc.rs
@@ -1,0 +1,162 @@
+//! Windows-only native window-procedure patches for the frameless main
+//! window. Everything here exists because a strip of pixels at the very
+//! top of a *maximized* frameless window is owned by native hit-testing,
+//! not by the web content — see `patch_maximized_hit_test` for the full
+//! mechanism and why no amount of CSS/JS can fix it.
+
+use windows::core::w;
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::UI::Shell::DefSubclassProc;
+use windows::Win32::UI::Shell::SetWindowSubclass;
+use windows::Win32::UI::WindowsAndMessaging::{
+    FindWindowExW, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCLIENT, HTLEFT, HTRIGHT, HTTOP,
+    HTTOPLEFT, HTTOPRIGHT, IsZoomed, ShowWindow, SW_HIDE, SW_SHOW, WM_NCHITTEST, WM_SIZE,
+};
+
+/// tauri-runtime-wry (pinned in Cargo.lock; this project tracks tauri 2.x
+/// via `tauri = "2"`) creates an invisible child HWND over every
+/// undecorated, resizable window to provide native edge-resizing —
+/// `undecorated_resizing.rs::attach_resize_handler`. The child is named
+/// `TAURI_DRAG_RESIZE_WINDOW` under class `TAURI_DRAG_RESIZE_BORDERS`, and
+/// its own window proc answers WM_NCHITTEST with HTTOP/HTLEFT/… for the
+/// border strip. Those class/window names are internal implementation
+/// details of tauri-runtime-wry, not a public API: if an upgrade ever
+/// stops matching, this module silently degrades to a no-op (nothing here
+/// is load-bearing for the rest of the app) but the maximized-window strip
+/// bug below comes back, so re-check `undecorated_resizing.rs` on upgrade.
+const TAURI_DRAG_RESIZE_CLASS: windows::core::PCWSTR = w!("TAURI_DRAG_RESIZE_BORDERS");
+const TAURI_DRAG_RESIZE_NAME: windows::core::PCWSTR = w!("TAURI_DRAG_RESIZE_WINDOW");
+
+const SUBCLASS_ID_PARENT: usize = 0x4453_4801; // "DSH" …01
+
+/// Fixes hit-testing quirks of maximized frameless windows on Windows.
+///
+/// The frameless window keeps the thick-frame window styles
+/// (WS_CAPTION|WS_SIZEBOX — see tao's `to_window_styles`) so resizing
+/// works, and tauri-runtime-wry adds the drag-resize child above for the
+/// actual edge dragging. Both hit-test paths only make sense while the
+/// window can *be* resized, but neither properly deactivates when the
+/// window is maximized:
+///
+/// - tauri-runtime-wry's own WM_SIZE handler does try to collapse the
+///   drag-resize child to 0×0 while maximized, but only when a WM_SIZE
+///   arrives *after* the child was attached. This window starts maximized
+///   (`maximized: true` in tauri.conf.json), and the child is attached
+///   after the window is already fully created and maximized — the
+///   maximize WM_SIZE fired before the attach, so the child stays at full
+///   client size with its border-strip region, answering HTTOP for the
+///   top strip of the screen even though the window can't be resized.
+/// - the parent's DefWindowProc still reports border hits for the
+///   window's edges; for a maximized window the top border sits exactly
+///   on the top row of the work area.
+///
+/// Result: the topmost row(s) of a maximized window get hit-tested as a
+/// resize border. Windows shows the vertical-resize cursor, and while a
+/// *move* over that strip can be routed onward (a transparent hit test
+/// passes it to the WebView2 beneath — hover highlight worked), a *click*
+/// is delivered as a non-client message and swallowed — the button never
+/// sees it. The shell's own flush-to-the-edge window controls (see
+/// styles.css `#window-controls`) sit exactly under that strip.
+///
+/// Fix (all in the parent-window subclass):
+///
+/// - **Hide the drag-resize child while maximized, show it when
+///   restored.** A hidden window takes no part in hit testing at all, so
+///   the strip behaves identically to every row below it: the hit test
+///   falls straight to the WebView2, and hover + click both work. When
+///   restored, showing the child restores edge-resizing as tauri
+///   designed it. The initial state is applied directly in
+///   `patch_maximized_hit_test` (covering the startup-maximized ordering
+///   where no WM_SIZE ever follows the attach), and kept in sync on every
+///   later WM_SIZE.
+/// - **Convert the parent's own border hits to HTCLIENT while
+///   maximized** (a maximized window can't be resized, and the resize
+///   cursor is exactly the complaint). On restore this passes through
+///   untouched, so edge-resizing still works.
+///
+/// The maximized state is re-checked on every message, so
+/// maximize/restore transitions need no bookkeeping beyond the WM_SIZE
+/// show/hide above.
+pub fn patch_maximized_hit_test(win: &tauri::WebviewWindow) {
+    let Ok(hwnd) = win.hwnd() else {
+        eprintln!("[dsh-desktop] window_proc: hwnd() failed");
+        return;
+    };
+
+    unsafe {
+        // The drag-resize child may legitimately be absent (e.g. if the
+        // window were ever configured non-resizable) — FindWindowExW
+        // errors out then, and the subclass just no-ops its child logic.
+        let child = FindWindowExW(Some(hwnd), None, TAURI_DRAG_RESIZE_CLASS, TAURI_DRAG_RESIZE_NAME)
+            .unwrap_or_default();
+        let _ = SetWindowSubclass(hwnd, Some(parent_proc), SUBCLASS_ID_PARENT, child.0 as usize);
+
+        // Startup-maximized ordering: the child was attached with the
+        // maximized client size and no WM_SIZE will follow to hide it —
+        // hide it now (and the WM_SIZE handler below keeps it in sync).
+        if !child.is_invalid() && IsZoomed(hwnd).as_bool() {
+            let _ = ShowWindow(child, SW_HIDE);
+        }
+    }
+}
+
+/// Parent-window subclass. Runs before tauri/tao's own window proc in the
+/// subclass chain (SetWindowSubclass calls the last-installed proc first),
+/// so this only ever adjusts behavior — never re-implements it.
+unsafe extern "system" fn parent_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+    _subclass_id: usize,
+    data: usize,
+) -> LRESULT {
+    let child = HWND(data as _);
+
+    match msg {
+        WM_SIZE => {
+            // The drag-resize child is only needed while the window can
+            // be edge-resized. Keep it hidden while maximized so it
+            // can't intercept hover/click at the screen's top strip; show
+            // it again on restore so tauri's own WM_SIZE handler (which
+            // runs after this one and re-sizes + re-regions the child)
+            // brings edge-resizing back.
+            if !child.is_invalid() {
+                if IsZoomed(hwnd).as_bool() {
+                    let _ = ShowWindow(child, SW_HIDE);
+                } else {
+                    let _ = ShowWindow(child, SW_SHOW);
+                }
+            }
+        }
+        WM_NCHITTEST => {
+            let result = DefSubclassProc(hwnd, msg, wparam, lparam);
+            if IsZoomed(hwnd).as_bool() {
+                // A maximized window can't be resized, so a border hit is
+                // useless — and at the top edge it's actively wrong
+                // (resize cursor, and mouse messages that would land in
+                // the non-client area instead of the page). Report the
+                // client area; the WebView2 child under the cursor then
+                // gets the mouse exactly like any other client point.
+                let hit = result.0 as u32;
+                if matches!(
+                    hit,
+                    HTTOP
+                        | HTTOPLEFT
+                        | HTTOPRIGHT
+                        | HTLEFT
+                        | HTRIGHT
+                        | HTBOTTOM
+                        | HTBOTTOMLEFT
+                        | HTBOTTOMRIGHT
+                ) {
+                    return LRESULT(HTCLIENT as _);
+                }
+            }
+            return result;
+        }
+        _ => {}
+    }
+
+    DefSubclassProc(hwnd, msg, wparam, lparam)
+}

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -140,7 +140,13 @@ body {
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  padding: 6px 10px;
+  /* No top/bottom/right padding: #window-controls must sit flush against
+     the window's top and right edges (OS-caption-button behavior, so the
+     corner-click gesture keeps working when maximized — see the
+     window-controls comment below). The button clusters restore their own
+     vertical breathing room via padding on #toolbar-left/#toolbar-actions
+     instead, so the bar height is unchanged. */
+  padding: 0 0 0 10px;
   background: var(--sidebar-bg);
   border-bottom: 1px solid var(--card-border);
   /* Anchors #toolbar-title's absolute centering below. */
@@ -186,6 +192,8 @@ body {
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  /* Vertical padding restored from #toolbar — see #toolbar-actions. */
+  padding: 6px 0;
 }
 
 #toolbar-actions {
@@ -194,6 +202,10 @@ body {
   gap: 4px;
   flex-shrink: 0;
   margin-left: auto;
+  /* Vertical padding restored from #toolbar (now edge-to-edge for the
+     window controls); the right 10px keeps the old 20px gap to
+     #window-controls' divider (10px here + its 10px margin-left). */
+  padding: 6px 10px 6px 0;
 }
 
 /* macOS restores the native title bar (see app.js's initWindowChrome), so
@@ -358,12 +370,26 @@ body.platform-decorated #toolbar-actions {
 }
 
 /* ── window controls: our own minimize/maximize/close, replacing the OS's ── */
+/*
+   These replace the OS caption buttons on the frameless Windows/Linux
+   builds, so they behave like OS caption buttons: full bar height, no
+   corner radius, and flush against the window's top/right edges (the
+   toolbar above carries no top/right padding of its own). With the window
+   maximized the close button's hover/click zone therefore reaches the
+   actual screen corner, preserving the muscle-memory "fling the mouse to
+   the top-right corner and click" gesture real title bars train. Width is
+   the Windows-standard 46px caption-button hit target, not the 30px icon-
+   button size the toolbar's other controls use.
+*/
 
 #window-controls {
   display: flex;
   align-items: center;
   gap: 2px;
   flex-shrink: 0;
+  /* Stretch to the bar's full height so the buttons can span top to
+     bottom edge (see .window-btn's height below). */
+  align-self: stretch;
   margin-left: 10px;
   padding-left: 10px;
   border-left: 1px solid var(--card-border);
@@ -373,12 +399,16 @@ body.platform-decorated #toolbar-actions {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 26px;
+  width: 46px;
+  /* Full bar height — #window-controls's stretch above fixes the row
+     height, so 100% makes each button span edge to edge, top to bottom. */
+  height: 100%;
   padding: 0;
   background: transparent;
   border: none;
-  border-radius: 6px;
+  /* No radius: a rounded corner would leave a dead zone right where the
+     screen corner is — the hover fill must cover the exact corner pixel. */
+  border-radius: 0;
   cursor: pointer;
   color: var(--muted);
 }


### PR DESCRIPTION
## What

Two changes, one goal: the custom minimize/maximize/close buttons (frameless Windows/Linux title bar) must behave like real OS caption buttons — flush to the screen edge when maximized, clickable at the very corner.

### 1. CSS — buttons flush to the window's top/right edges

The buttons no longer sit 10px from the right edge and 6px below the top: they are flush against the window's top/right edges, span the full bar height, have no corner radius, and grew from 30px to the Windows-standard 46px caption-button hit width.

### 2. Native hit-testing — the maximized window's top strip is clickable

Even with the buttons flush to the edge, the topmost row(s) of a maximized frameless window are hit-tested as a resize border by Windows:

- tauri-runtime-wry's invisible drag-resize child (`undecorated_resizing.rs`) keeps its border strip — its WM_SIZE collapse to 0×0 never runs in the startup-maximized ordering (the child is attached after the window is already maximized, so no WM_SIZE follows)
- the parent's `DefWindowProc` reports `HTTOP` for the top border even though a maximized window can't be resized

Result: vertical-resize cursor + the web content never gets the mouse; hover routing alone (HTTRANSPARENT) left the click swallowed as a non-client message.

Fix: new `src-tauri/src/window_proc.rs` (Windows-only, attached from the setup hook) subclasses the parent window and **hides the drag-resize child while maximized** (initial state + WM_SIZE sync), so the strip behaves exactly like every row below it — the hit test falls straight to the WebView2 and hover/click both work — and converts the parent's own border hits to `HTCLIENT` while maximized so no resize cursor shows. Both pass through untouched when restored, so edge-resizing still works.

## Why

The window starts maximized (`tauri.conf.json`), so before these changes the top-right corner of the screen was dead: a resize cursor over a non-clickable strip. Users fling the mouse to the corner to close a maximized window — that muscle-memory gesture now works.

## Details

- CSS only in commit 1: `#toolbar` dropped its top/bottom/right padding; the button clusters restore their own 6px vertical padding, so the bar height is unchanged; the 20px gap to the window-controls divider is preserved
- macOS is untouched (native traffic lights; `window_proc.rs` is `cfg(windows)`-gated, CSS controls stay hidden)
- The drag-resize child is found by its internal class/window names (`TAURI_DRAG_RESIZE_BORDERS`/`TAURI_DRAG_RESIZE_WINDOW`) — documented as fragile against tauri-runtime-wry upgrades (pinned in Cargo.lock)

## Verification

- `cargo build` (debug) succeeds; tested in the real window by the maintainer: top-row hover + click on the close button works when maximized, edge-resizing still works when restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)