### PR TITLE
chore: bump version to 1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui",


### PR DESCRIPTION
## What

Shell version bump 1.5.3 → 1.5.4 (package.json + tauri.conf.json), carrying the merged window-controls work from #37:

- buttons flush to the window's top/right edges with the Windows-standard 46px hit width
- native hit-testing fix making the maximized window's top strip clickable (new `src-tauri/src/window_proc.rs`)

Runtime check passed locally: pinned `@deepseek-ai/dsh` (`0.1.1-rc.2`) matches npm `latest` — no runtime bump needed. CI runs the same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)