### PR TITLE
fix: plugin install, boot, and shutdown resilience

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,17 +14,17 @@ mod terminal;
 #[cfg(windows)]
 mod window_proc;
 
+use std::fs;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use serde::{Deserialize, Serialize};
 use tauri::menu::CheckMenuItem;
-use tauri::{AppHandle, Manager, RunEvent, State, WindowEvent, Wry};
+use tauri::{AppHandle, Emitter, Manager, RunEvent, State, WindowEvent, Wry};
 use tauri_plugin_autostart::ManagerExt as _;
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt as _, Modifiers, Shortcut, ShortcutState};
-use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_updater::UpdaterExt;
 
@@ -49,10 +49,55 @@ fn requested_workspace(args: &[String]) -> Option<std::path::PathBuf> {
 
 use server::{DshServer, ServerStatus};
 
+/// The user's remembered choice for what the window's close button (X)
+/// should do, persisted across restarts once they've explicitly picked one
+/// in the close-confirmation dialog and checked "remember". `None` — the
+/// default, and also what a missing/corrupt settings file falls back to —
+/// means "ask every time"; see `WindowEvent::CloseRequested` below.
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum CloseAction {
+    Minimize,
+    Quit,
+}
+
+/// Settings file holding the remembered `CloseAction`, if any — lives
+/// alongside the persistent desktop log (`app_log_dir()`; confirmed to
+/// resolve correctly for both packaged and unpackaged builds, unlike
+/// `app_cache_dir()` — see server.rs's `runtime_dir` doc comment), not
+/// inside `~/.dsh`, which is dsh's own data directory (a different
+/// project's domain — see this crate's module doc).
+fn close_action_settings_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path().app_log_dir().ok().map(|dir| dir.join("close-action.json"))
+}
+
+/// Reads the remembered close action, if any was ever saved. Any failure
+/// (missing file, unreadable, malformed JSON) is treated the same as "never
+/// saved one" — this is a convenience default, not data worth surfacing an
+/// error over.
+fn load_close_action(app: &AppHandle) -> Option<CloseAction> {
+    let path = close_action_settings_path(app)?;
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Persists the remembered close action for future launches.
+fn save_close_action(app: &AppHandle, action: CloseAction) {
+    let Some(path) = close_action_settings_path(app) else { return };
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    if let Ok(text) = serde_json::to_string(&action) {
+        let _ = fs::write(path, text);
+    }
+}
+
 pub struct AppState {
     pub server: Arc<Mutex<DshServer>>,
-    /// Whether the one-time "minimized to tray" notice has fired this run.
-    hide_notice_shown: AtomicBool,
+    /// The remembered answer to "what should the close button do", loaded
+    /// from disk at startup (see `load_close_action`) and updated by the
+    /// `resolve_close_choice` command whenever the user checks "remember".
+    close_action: Mutex<Option<CloseAction>>,
     /// The tray's "开机自动启动" checkbox — kept here so
     /// `MENU_TOGGLE_AUTOSTART` can sync its visual state after toggling
     /// (clicking a `CheckMenuItem` doesn't flip its own display automatically).
@@ -60,6 +105,29 @@ pub struct AppState {
 }
 
 // ── commands (called only from the local boot page) ─────────────────────────
+
+/// Carries out the user's answer to the close-confirmation dialog (shown in
+/// response to the `request-close-choice` event — see
+/// `WindowEvent::CloseRequested`). `remember` persists the choice via
+/// `save_close_action` so future closes this run *and* future launches skip
+/// the dialog entirely and just do it; leaving it unchecked means this
+/// answer covers only the close that's happening right now.
+#[tauri::command]
+fn resolve_close_choice(app: AppHandle, quit: bool, remember: bool) {
+    let action = if quit { CloseAction::Quit } else { CloseAction::Minimize };
+    if remember {
+        *app.state::<AppState>().close_action.lock().unwrap() = Some(action);
+        save_close_action(&app, action);
+    }
+    match action {
+        CloseAction::Minimize => {
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.hide();
+            }
+        }
+        CloseAction::Quit => app.exit(0),
+    }
+}
 
 #[tauri::command]
 fn get_status(state: State<'_, AppState>) -> ServerStatus {
@@ -828,6 +896,27 @@ pub fn run() {
         }
     }
 
+    // Created here rather than inside `.setup()` (its previous home) so the
+    // panic hook below can close over it too — `.setup()` doesn't run until
+    // the event loop is already live, which is too late to cover a panic
+    // during the builder chain itself, however unlikely.
+    let srv = Arc::new(Mutex::new(DshServer::default()));
+
+    // Every *normal* quit path (window close, tray 退出, updater restart)
+    // funnels through `RunEvent::ExitRequested` below, which tears the dsh
+    // child process down. A panic doesn't: it unwinds past that entirely,
+    // and if it happens to take down the event-loop thread, the child is
+    // orphaned with zero cleanup. This is the safety net — best-effort, but
+    // strictly better than nothing. Chains the previous hook (Tauri/the
+    // default runtime's own) rather than replacing it, so panic messages
+    // still get logged/reported the same as before.
+    server::init_panic_cleanup(srv.clone());
+    let previous_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        server::cleanup_on_panic();
+        previous_panic_hook(info);
+    }));
+
     tauri::Builder::default()
         // Must be the first plugin registered: it needs to claim the
         // single-instance lock before anything else in the builder chain
@@ -883,6 +972,7 @@ pub fn run() {
                 .build(),
         )
         .invoke_handler(tauri::generate_handler![
+            resolve_close_choice,
             get_status,
             get_info,
             start_server,
@@ -918,7 +1008,7 @@ pub fn run() {
             terminal::terminal_resize,
             terminal::terminal_close
         ])
-        .setup(|app| {
+        .setup(move |app| {
             let handle = app.handle().clone();
 
             // Persistent log file for the desktop shell itself.
@@ -926,10 +1016,13 @@ pub fn run() {
                 server::init_log_file(log_dir.join("desktop.log"));
             }
 
-            // Built directly rather than via `app.state()` — AppState isn't
-            // `manage()`d until below, once `build_tray` has handed back the
-            // autostart checkbox it needs to be constructed with.
-            let srv = Arc::new(Mutex::new(DshServer::default()));
+            // `srv` itself (not a fresh one — `AppState` isn't `manage()`d
+            // until below, once `build_tray` has handed back the autostart
+            // checkbox it needs to be constructed with) is the same instance
+            // the panic hook above already closed over, created before this
+            // closure so both share one server rather than racing to set up
+            // two independent ones.
+            let close_action = Mutex::new(load_close_action(&handle));
 
             // The container page (ui/) hosts the harness in an <iframe> and
             // never navigates its own top level — these WebView2-level
@@ -982,7 +1075,7 @@ pub fn run() {
 
             app.manage(AppState {
                 server: srv.clone(),
-                hide_notice_shown: AtomicBool::new(false),
+                close_action,
                 autostart_item,
             });
             app.manage(terminal::TerminalState::default());
@@ -996,29 +1089,30 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
-                // Tray-resident mode: closing the window hides it but leaves
-                // the dsh server running in the background. Quitting (⌘Q /
-                // tray 退出) tears the server down in the ExitRequested
-                // handler and then exits the process.
+                // Always intercept the raw OS-level close — what actually
+                // happens next (minimize to tray, or quit) is decided below,
+                // never by letting this proceed unprompted.
                 api.prevent_close();
-                let _ = window.hide();
-
                 let app = window.app_handle();
-                let state = app.state::<AppState>();
-                if state.hide_notice_shown.swap(true, Ordering::Relaxed) {
-                    return;
+                let remembered = *app.state::<AppState>().close_action.lock().unwrap();
+                match remembered {
+                    Some(CloseAction::Minimize) => {
+                        let _ = window.hide();
+                    }
+                    Some(CloseAction::Quit) => {
+                        // Quitting (⌘Q / tray 退出 / a remembered "quit" here)
+                        // all tear the server down in the ExitRequested
+                        // handler below and then exit the process.
+                        app.exit(0);
+                    }
+                    // No remembered choice yet: ask, via a dialog on the boot
+                    // page — resolve_close_choice carries out whatever the
+                    // user picks. Don't hide or quit here; either would race
+                    // ahead of the user's actual answer.
+                    None => {
+                        let _ = app.emit("request-close-choice", ());
+                    }
                 }
-                let lang = i18n::detect();
-                let _ = app
-                    .notification()
-                    .builder()
-                    .title(i18n::tr(lang, "DeepSeek Harness 已转入后台", "DeepSeek Harness is running in the background"))
-                    .body(i18n::tr(
-                        lang,
-                        "服务仍在运行；从系统托盘图标可重新打开窗口或退出。",
-                        "The service is still running. Use the tray icon to reopen the window or quit.",
-                    ))
-                    .show();
             }
         })
         .on_menu_event(|app, event| handle_menu_action(app, event.id.as_ref()))

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1139,11 +1139,24 @@ fn spawn(app: &AppHandle, server: &Shared, node: &str, bin: &str, port: u16) -> 
 
     push_log(
         server,
-        format!("启动: {node} {bin} web --port {port}  (cwd: {cwd_plain})"),
+        format!("启动: {node} {bin} web --port {port} --no-open  (cwd: {cwd_plain})"),
     );
 
     let mut cmd = Command::new(node);
-    cmd.arg(bin).arg("web").arg("--port").arg(port.to_string());
+    // --no-open: dsh's web-app bundle opens the host's default browser on
+    // startup (outside SSH) unless told not to. This shell is the intended
+    // surface — the harness page is loaded into our own window via the
+    // iframe above — so an extra system browser tab popping open alongside
+    // it is a visible regression, not a feature this app wants. This was
+    // added once already (0.1.0-rc.8) and dropped when that version got
+    // reverted for being unpromoted upstream, because rc.7's CLI didn't
+    // recognize the flag at all ("unknown option '--no-open'" — a hard
+    // startup crash, not a no-op). Confirmed directly against the currently
+    // pinned 0.1.1-rc.2 (`node bin.js web --port <scratch> --no-open`) before
+    // re-adding: starts cleanly, suppresses the browser-open log line, no
+    // "unknown option" error — safe on this version specifically, which is
+    // the part that broke last time.
+    cmd.arg(bin).arg("web").arg("--port").arg(port.to_string()).arg("--no-open");
     cmd.current_dir(&cwd_plain);
     // See `effective_path`: every tool call dsh shells out to on the
     // agent's behalf inherits this, so a stale/truncated PATH here doesn't

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -596,7 +596,23 @@ pub fn install_plugin(app: &AppHandle, server: &Shared, package: &str) -> Result
     };
 
     let mut cmd = Command::new(&node);
-    cmd.arg(&bin).arg("plugin").arg("--profile").arg("web").arg("add").arg(package);
+    // -w (forwarded to pnpm as --workspace-root): dsh scaffolds every
+    // profile directory as a single-package pnpm workspace (`packages: [.]`
+    // in its own generated pnpm-workspace.yaml — not something dsh-desktop
+    // creates), and dsh's own `plugin add` never passes pnpm the flag that
+    // acknowledges this. Without it, pnpm refuses outright with
+    // ERR_PNPM_ADDING_TO_ROOT ("Running this command will add the
+    // dependency to the workspace root... if you really meant it, make it
+    // explicit by running this command again with the -w flag") — every
+    // plugin-market install fails this way on the currently pinned dsh
+    // version. Confirmed directly (`dsh plugin --profile web add -w
+    // <pkg>` against a real profile) before adding: installs cleanly.
+    // `dsh plugin`'s own arguments are forwarded to pnpm verbatim, so this
+    // rides along with no other change needed. `heal_missing_plugin`'s
+    // `remove` doesn't need the same flag — pnpm's workspace-root guard
+    // only exists for `add` (which package.json would a *new* dependency
+    // even go into?); removing an already-declared one is unambiguous.
+    cmd.arg(&bin).arg("plugin").arg("--profile").arg("web").arg("add").arg("-w").arg(package);
     // Same PATH rebuild as the server process itself — pnpm needs a real
     // PATH to find node/git, not whatever this GUI process happened to
     // inherit at launch. See `effective_path`'s own doc comment.

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -821,6 +821,106 @@ fn heal_stale_symlink(app: &AppHandle, server: &Shared, path: &Path) -> bool {
     }
 }
 
+// ── self-heal: missing marketplace plugin files ─────────────────────────────
+
+/// Extracts the plugin name from a dsh boot error caused by a
+/// marketplace-installed plugin's compiled entry file going missing from
+/// disk (interrupted `pnpm add`, or something else deleting it after the
+/// fact) — the cordis loader treats any single unresolvable plugin entry as
+/// fatal for the *whole* plugin tree, so this crashes `dsh web` outright
+/// (same failure class as upstream
+/// deepseek-ai/deepseek-harness#880/#2603, unfixed as of writing). Observed
+/// shape, captured verbatim from a real user's log
+/// (dsh-desktop issue #41):
+/// `Cannot find module 'C:\Users\x\.dsh\extension-manager\plugins\dsh-plugin-sodamem\dist\cjs\index.js' imported from ...`
+/// Anchored on the real `<dsh_home>/extension-manager/plugins/` filesystem
+/// prefix rather than the surrounding English error prose — same
+/// safety-fence approach as `heal_stale_symlink` above, and more stable
+/// across upstream wording changes than matching on message text. Takes the
+/// prefix pre-computed (rather than an `AppHandle` to derive it from) so
+/// this stays pure text parsing, same as `extract_stale_symlink_path` —
+/// callers compute it once via `dsh_home_dir` instead of paying for it on
+/// every line scanned.
+fn extract_missing_plugin_name(plugins_dir: &Path, line: &str) -> Option<String> {
+    let prefix = plugins_dir.to_string_lossy();
+    let idx = line.find(prefix.as_ref())?;
+    let rest = &line[idx + prefix.len()..];
+    let rest = rest.strip_prefix(['\\', '/'])?;
+    let end = rest.find(['\\', '/'])?;
+    let name = &rest[..end];
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Removes a marketplace plugin whose compiled entry file is missing from
+/// disk (see `extract_missing_plugin_name`) via dsh's own supported `plugin
+/// remove` command — not a direct edit to the profile's package.json/bundles
+/// list. A related upstream report (deepseek-ai/deepseek-harness#3263)
+/// documents that dsh's own reconcile logic can silently re-add a package to
+/// `bundles` on the next plugin-market install/update if it's still listed
+/// as a dependency — hand-editing the config directly would fight that
+/// logic instead of going through it; `dsh plugin remove` forwards to `pnpm
+/// remove` and lets dsh reconcile both `dependencies` and `bundles`
+/// consistently in one step (confirmed against the published CLI source,
+/// `@deepseek-ai/dsh`'s `lib/bin.js`: `plugin` forwards its arguments
+/// verbatim to pnpm in the profile directory; its own help text lists
+/// `remove <pkg>` as a supported form).
+///
+/// Runs synchronously (unlike `install_plugin`, which streams progress to
+/// the UI for a user-triggered install) since this is called from
+/// `start_inner`'s own blocking retry loop. Shares `plugin_install_pid` with
+/// `install_plugin` — both are `dsh plugin --profile web <verb>` mutations
+/// against the same profile, and must not run concurrently: the dock's
+/// plugin market is a native panel independent of the iframe, so a user can
+/// trigger an install even while the main service is stuck in a
+/// boot-failure retry loop. If the lock is already held, this returns
+/// `false` without touching anything — not counted as a failed heal
+/// attempt, since nothing was actually tried; the retry loop's own polling
+/// naturally re-checks on the next tick once the lock frees up. Doesn't need
+/// an `AppHandle`: the safety fence (is this path actually a
+/// marketplace-plugin location?) already happened one step upstream, in
+/// `extract_missing_plugin_name` — by the time a name reaches here it's
+/// already known to have come from the expected `extension-manager/plugins`
+/// location.
+fn heal_missing_plugin(server: &Shared, node: &str, bin: &str, name: &str) -> bool {
+    {
+        let mut s = server.lock().unwrap();
+        if s.plugin_install_pid.is_some() {
+            return false;
+        }
+        s.plugin_install_pid = Some(0);
+    }
+    push_log(server, format!("检测到插件 {name} 的文件缺失，正在自动移除以恢复启动…"));
+    let mut cmd = Command::new(node);
+    cmd.arg(bin).arg("plugin").arg("--profile").arg("web").arg("remove").arg(name);
+    cmd.env("PATH", effective_path());
+    cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    own_process_group(&mut cmd);
+    hide_console(&mut cmd);
+    let result = cmd.status();
+    server.lock().unwrap().plugin_install_pid = None;
+    match result {
+        Ok(status) if status.success() => {
+            push_log(
+                server,
+                format!("已自动移除插件 {name}（文件缺失，可能是安装未完成或被外部程序删除）。如需继续使用请重新安装。"),
+            );
+            true
+        }
+        Ok(status) => {
+            push_log(server, format!("自动移除插件 {name} 失败(exit {:?})。", status.code()));
+            false
+        }
+        Err(e) => {
+            push_log(server, format!("自动移除插件 {name} 失败：{e}"));
+            false
+        }
+    }
+}
+
 // ── PATH ─────────────────────────────────────────────────────────────────────
 
 /// A GUI app launched from Explorer/Start Menu inherits whatever `PATH` its
@@ -1283,15 +1383,23 @@ fn start_inner(app: &AppHandle, server: &Shared) -> Result<(), String> {
     // forever.
     let ready_deadline = Instant::now() + READY_TIMEOUT;
     let mut heal_attempts = 0u32;
+    // Counted separately from `heal_attempts` above: a single boot attempt
+    // can plausibly need to clear a stale symlink *and* remove a broken
+    // plugin, and one heal class exhausting its budget shouldn't starve the
+    // other.
+    let mut plugin_heal_attempts = 0u32;
+    let plugins_dir = dsh_home_dir(app).join("extension-manager").join("plugins");
     loop {
-        let (running, exited, eaddr, stale_symlink) = {
+        let (running, exited, eaddr, stale_symlink, missing_plugin) = {
             let s = server.lock().unwrap();
             let stale_symlink = s.logs.iter().rev().find_map(|l| extract_stale_symlink_path(l));
+            let missing_plugin = s.logs.iter().rev().find_map(|l| extract_missing_plugin_name(&plugins_dir, l));
             (
                 matches!(s.status, ServerStatus::Running { .. }),
                 s.pid.is_none(),
                 s.logs.iter().any(|l| l.contains("EADDRINUSE")),
                 stale_symlink,
+                missing_plugin,
             )
         };
         if running {
@@ -1332,6 +1440,13 @@ fn start_inner(app: &AppHandle, server: &Shared) -> Result<(), String> {
             if let Some(path) = &stale_symlink {
                 if heal_attempts < MAX_HEAL_ATTEMPTS && heal_stale_symlink(app, server, path) {
                     heal_attempts += 1;
+                    spawn(app, server, &node, &bin, port)?;
+                    continue;
+                }
+            }
+            if let Some(name) = &missing_plugin {
+                if plugin_heal_attempts < MAX_HEAL_ATTEMPTS && heal_missing_plugin(server, &node, &bin, name) {
+                    plugin_heal_attempts += 1;
                     spawn(app, server, &node, &bin, port)?;
                     continue;
                 }
@@ -1423,6 +1538,45 @@ mod tests {
             extract_stale_symlink_path("exists and is not a symlink; remove it so dsh can manage the installation fallback"),
             None
         );
+    }
+
+    // Real error line captured verbatim from a user's log (dsh-desktop
+    // issue #41): a marketplace plugin's compiled entry file was missing
+    // from disk, and the cordis loader's fatal-per-entry failure crashed the
+    // whole `dsh web` process. Real captured prefix uses the actual
+    // reporter's (Windows, Chinese-username) `~/.dsh` layout.
+    const REAL_MISSING_PLUGIN_LINE: &str = r"Cannot find module 'C:\Users\一一的最爱\.dsh\extension-manager\plugins\dsh-plugin-sodamem\dist\cjs\index.js' imported from C:\Users\一一的最爱\.dsh\profiles\web\";
+
+    fn real_plugins_dir() -> PathBuf {
+        PathBuf::from(r"C:\Users\一一的最爱\.dsh\extension-manager\plugins")
+    }
+
+    #[test]
+    fn extracts_plugin_name_from_a_real_captured_error() {
+        assert_eq!(
+            extract_missing_plugin_name(&real_plugins_dir(), REAL_MISSING_PLUGIN_LINE),
+            Some("dsh-plugin-sodamem".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_lines_unrelated_to_missing_plugins() {
+        let dir = real_plugins_dir();
+        assert_eq!(extract_missing_plugin_name(&dir, "dsh web: http://127.0.0.1:3080"), None);
+        assert_eq!(extract_missing_plugin_name(&dir, ""), None);
+        assert_eq!(
+            extract_missing_plugin_name(&dir, "some other error entirely unrelated to plugins"),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_extension_manager_prefix_without_a_plugin_name_after_it() {
+        // The prefix is present but truncated right at the plugins/
+        // boundary — no trailing path segment to read a name from.
+        let dir = real_plugins_dir();
+        let line = format!("something something {}", dir.display());
+        assert_eq!(extract_missing_plugin_name(&dir, &line), None);
     }
 
     #[test]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -85,6 +85,43 @@ fn append_log_file(line: &str) {
     }
 }
 
+/// Holds the shared server state so a panic hook — installed at process
+/// startup, before any window or Tauri state exists — can still reach the
+/// tracked child pid from whatever thread happens to panic. Set once via
+/// [`init_panic_cleanup`]. A plain global rather than something threaded
+/// through `AppHandle`: a panic hook has no access to Tauri's managed state,
+/// only whatever it closed over at `set_hook` time.
+static PANIC_CLEANUP_SERVER: OnceLock<Shared> = OnceLock::new();
+
+/// Registers the server state for [`cleanup_on_panic`] to use. Called once
+/// at startup, before the panic hook is installed.
+pub fn init_panic_cleanup(server: Shared) {
+    let _ = PANIC_CLEANUP_SERVER.set(server);
+}
+
+/// Best-effort child-process cleanup for an unhandled panic. Every *normal*
+/// quit path (window close, tray 退出, updater restart) funnels through
+/// `RunEvent::ExitRequested` in lib.rs, which calls `stop()` — but a panic
+/// unwinds past that entirely; if it happens to take down the event-loop
+/// thread, `ExitRequested` never fires and the dsh child process is
+/// silently orphaned with no cleanup at all. This is the safety net,
+/// installed as the process's panic hook.
+///
+/// Tolerates a poisoned mutex on purpose: the panic that triggered this
+/// call may itself have happened on a different thread while that thread
+/// held this exact lock (this app has many background readers/watchers
+/// all doing `server.lock().unwrap()`), which is precisely the scenario
+/// this hook exists for — recovering the guard via `into_inner()` still
+/// gets a real (if possibly mid-update) pid to kill, which is strictly
+/// better than giving up because the data might be stale.
+pub fn cleanup_on_panic() {
+    let Some(server) = PANIC_CLEANUP_SERVER.get() else { return };
+    let pid = server.lock().unwrap_or_else(|e| e.into_inner()).pid;
+    if let Some(pid) = pid {
+        kill_process_tree(pid);
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "state", rename_all = "camelCase")]
 pub enum ServerStatus {

--- a/ui/app.js
+++ b/ui/app.js
@@ -97,6 +97,10 @@ const els = {
   confirmDialogInput: document.getElementById("confirm-dialog-input"),
   btnConfirmDialogCancel: document.getElementById("btn-confirm-dialog-cancel"),
   btnConfirmDialogOk: document.getElementById("btn-confirm-dialog-ok"),
+  closeChoiceOverlay: document.getElementById("close-choice-overlay"),
+  closeChoiceRemember: document.getElementById("close-choice-remember"),
+  btnCloseChoiceMinimize: document.getElementById("btn-close-choice-minimize"),
+  btnCloseChoiceQuit: document.getElementById("btn-close-choice-quit"),
 };
 
 // ── i18n ─────────────────────────────────────────────────────────────────
@@ -146,6 +150,10 @@ const STRINGS = {
       "首次使用提示：默认使用 DeepSeek 官方模型。如需接入 OpenAI / Anthropic / Gemini " +
       "等其他模型，进入后可在「设置 → 模型 → 添加提供方」中配置，随时可改。",
     gotIt: "知道了",
+    closeChoiceMessage: "要将 DeepSeek Harness 最小化到系统托盘（服务继续在后台运行），还是直接退出？",
+    closeChoiceRemember: "记住我的选择，以后不再询问",
+    closeChoiceMinimize: "最小化到托盘",
+    closeChoiceQuit: "退出",
     startupFailed: "启动失败",
     retry: "重试",
     refreshTreeTitle: "刷新文件树与 Git 状态",
@@ -273,6 +281,10 @@ const STRINGS = {
       "First time here: DeepSeek's official models are used by default. To add OpenAI / Anthropic / " +
       "Gemini or other providers, go to Settings → Models → Add Provider after launch — you can change this anytime.",
     gotIt: "Got It",
+    closeChoiceMessage: "Minimize DeepSeek Harness to the system tray (the service keeps running in the background), or quit?",
+    closeChoiceRemember: "Remember my choice, don't ask again",
+    closeChoiceMinimize: "Minimize to Tray",
+    closeChoiceQuit: "Quit",
     startupFailed: "Startup Failed",
     retry: "Retry",
     refreshTreeTitle: "Refresh file tree and Git status",
@@ -2980,6 +2992,23 @@ async function init() {
       // anyway (e.g. a post-install warning unrelated to the binary itself).
       if (!els.pluginMarketConfirm.classList.contains("hidden")) refreshPnpmGate();
     }
+  });
+  // Fired by WindowEvent::CloseRequested (lib.rs) whenever there's no
+  // remembered close-action yet — once the user picks one via
+  // resolve_close_choice and checks "remember", this stops firing entirely
+  // (Rust applies the remembered choice directly, no round trip here).
+  listen("request-close-choice", () => {
+    els.closeChoiceRemember.checked = false;
+    els.closeChoiceOverlay.classList.remove("hidden");
+    els.btnCloseChoiceMinimize.focus();
+  });
+  els.btnCloseChoiceMinimize.addEventListener("click", () => {
+    els.closeChoiceOverlay.classList.add("hidden");
+    invoke("resolve_close_choice", { quit: false, remember: els.closeChoiceRemember.checked });
+  });
+  els.btnCloseChoiceQuit.addEventListener("click", () => {
+    els.closeChoiceOverlay.classList.add("hidden");
+    invoke("resolve_close_choice", { quit: true, remember: els.closeChoiceRemember.checked });
   });
   els.btnRetry.addEventListener("click", () => {
     els.btnRetry.disabled = true;

--- a/ui/index.html
+++ b/ui/index.html
@@ -528,6 +528,28 @@
       </div>
     </div>
     <!--
+      Shown on every window-close click (the X button) until the user picks
+      an answer and checks "remember" — see the "request-close-choice" event
+      handling in app.js and lib.rs's WindowEvent::CloseRequested. A separate
+      overlay from #confirm-dialog-overlay rather than a third openDialog()
+      shape: this is two equally-valid choices plus a remember checkbox, not
+      a confirm/cancel-of-one-action pair, so it doesn't fit that helper's
+      OK/Cancel model.
+    -->
+    <div id="close-choice-overlay" class="hidden">
+      <div id="close-choice-dialog" role="alertdialog" aria-modal="true" aria-describedby="close-choice-message">
+        <p id="close-choice-message" data-i18n="closeChoiceMessage"></p>
+        <label id="close-choice-remember-label">
+          <input id="close-choice-remember" type="checkbox" />
+          <span data-i18n="closeChoiceRemember"></span>
+        </label>
+        <div id="close-choice-actions" class="actions">
+          <button id="btn-close-choice-quit" data-i18n="closeChoiceQuit"></button>
+          <button id="btn-close-choice-minimize" class="primary" data-i18n="closeChoiceMinimize"></button>
+        </div>
+      </div>
+    </div>
+    <!--
       File tree right-click menu (see openTreeContextMenu in app.js) — built
       fresh into this one empty container on every right-click rather than a
       static template, since which items show up depends on what was

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1258,6 +1258,59 @@ body.platform-decorated #toolbar-actions {
   opacity: 0.85;
 }
 
+/* ── close-choice dialog: same card/overlay treatment as #confirm-dialog ── */
+
+#close-choice-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+#close-choice-overlay.hidden {
+  display: none;
+}
+
+#close-choice-dialog {
+  width: min(360px, 100%);
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  box-shadow: var(--card-shadow);
+  padding: 20px;
+  animation: boot-card-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+#close-choice-message {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+#close-choice-remember-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+#close-choice-remember {
+  margin: 0;
+}
+
+#close-choice-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 /* ── resize handle: draggable, persisted dock-vs-content split ── */
 
 /* A real 8px-wide flex item (not a thin line widened via a negative-margin


### PR DESCRIPTION
## Summary
- Self-heal `dsh web` boot failures caused by a marketplace plugin's compiled entry file going missing (interrupted install, or deleted after the fact) — the cordis loader currently treats this as fatal for the whole plugin tree, and the existing exit-watcher's blind restart can't recover since the missing file doesn't reappear. Mirrors the existing stale-symlink self-heal: detect it, remove the broken plugin via `dsh plugin remove`, retry.
- Restore `--no-open` on the `dsh web` spawn, dropped as collateral damage when the rc.8 bump got reverted (rc.7 didn't support the flag at all). Confirmed directly against the currently pinned `0.1.1-rc.2` before re-adding.
- Pass `-w` to pnpm on plugin-market installs. dsh scaffolds every profile as a single-package pnpm workspace but its own `plugin add` never passes the flag acknowledging that, so every marketplace install was failing outright with `ERR_PNPM_ADDING_TO_ROOT`. Confirmed against a real profile before adding.
- Confirm-before-close dialog + a panic-time cleanup safety net, addressing the "node process left running after quit" report. Closing the window (X) now asks minimize-vs-quit explicitly (with a "remember this" checkbox), instead of always silently minimizing behind a notification that only ever shows once per session. Also adds a panic hook — previously nonexistent anywhere in the app — that makes a best-effort attempt to kill the tracked dsh process tree before the process dies, covering the case where a panic (rather than a normal quit) is what leaves the child orphaned.

Fixes [xiincs/deepseek-harness-desktop#41](https://github.com/xiincs/deepseek-harness-desktop/issues/41). Addresses item 3 of [xiincs/deepseek-harness-desktop#42](https://github.com/xiincs/deepseek-harness-desktop/issues/42).

## Test plan
- [x] `cargo check --no-default-features`
- [x] `cargo test --no-default-features` (53 passed)
- [x] `cargo build --no-default-features`
- [x] `--no-open` verified directly against a real `dsh web --port <scratch> --no-open` invocation on the pinned dsh version (starts cleanly, suppresses browser-open, no "unknown option" error)
- [x] `-w` fix verified directly against a real broken profile (`dsh plugin --profile web add -w <pkg>` installs cleanly)
- [ ] Manual verification in a real window: self-heal path (simulate a plugin with a missing `dist` file), close-confirmation dialog (both choices, remember checkbox, restart to confirm persistence), panic hook (hard to simulate safely — lower-confidence path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)