### PR TITLE
chore: bump version to 1.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "private": true,
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Desktop app for DeepSeek Harness (Tauri wrapper around `dsh web`)",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "identifier": "dev.dsh.desktop",
   "build": {
     "frontendDist": "../ui",


### PR DESCRIPTION
## Summary
- Bump shell version to 1.5.5 (`package.json`, `src-tauri/tauri.conf.json`) to release the fixes landed in #43: plugin-market install self-heal + `-w` pnpm fix, restored `--no-open`, and the close-confirmation dialog / panic-time cleanup.
- Runtime pin (`DSH_VERSION_DEFAULT` = `0.1.1-rc.2`) unchanged — already matches npm's `latest` dist-tag.

## Test plan
- [x] `npm run check:dsh-version` equivalent (curl against npm registry) confirms `0.1.1-rc.2` == `latest`
- [ ] CI `release.yml` build on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)